### PR TITLE
Allow custom parallelization functor.

### DIFF
--- a/src/ducc0/infra/threading.h
+++ b/src/ducc0/infra/threading.h
@@ -240,6 +240,7 @@ template<typename T, typename Func> auto execWorklist
 
 using detail_threading::max_threads;
 using detail_threading::adjust_nthreads;
+using detail_threading::Range;
 using detail_threading::Scheduler;
 using detail_threading::execSingle;
 using detail_threading::execStatic;


### PR DESCRIPTION
This is to support the use of a custom threadpool, like Eigen's or TensorFlow's.  This will enable JAX/TF to use DUCC0 for FFTs with multithreading.