### PR TITLE
Allow custom parallelization functor (version 2).

### DIFF
--- a/src/ducc0/infra/threading.h
+++ b/src/ducc0/infra/threading.h
@@ -240,6 +240,7 @@ template<typename T, typename Func> auto execWorklist
 
 using detail_threading::max_threads;
 using detail_threading::adjust_nthreads;
+using detail_threading::Range;
 using detail_threading::Scheduler;
 using detail_threading::execSingle;
 using detail_threading::execStatic;


### PR DESCRIPTION
This is to support the use of a custom threadpool, like Eigen's or TensorFlow's.  This will enable JAX/TF to use DUCC0 for FFTs with multithreading.

This alternative implementation provides more details to the custom threading module for computing chunks of work (i.e. input `fmav_info`, `axis`, `vlen`).  It also replaces the `execParallel` calls with the more generic threading routines (like `execStatic`, `execDynamic`) to allow custom division of work via `Scheduler::getNext()`.  This would allow TF/Eigen to make use of their cost-based recursive `ParallelFor` routines.