### PR TITLE
Gradient only SHTs

### DIFF
--- a/python/misc_pymod.cc
+++ b/python/misc_pymod.cc
@@ -797,7 +797,6 @@ py::array Py_get_deflected_angles2(const py::array &theta_,
         if (calc_rotation)
           MR_assert(e_r.x > 0, "for the poles fix alpha=0 case in calc_rotation first ");
         double dphi = 2*pi/nphi(iring);
-        double sin_aoa, twohav_aod, cos_a;
         for (size_t iphi=0; iphi<nphi(iring); ++iphi)
           {
           double phi = phi0(iring) + iphi*dphi;
@@ -805,6 +804,7 @@ py::array Py_get_deflected_angles2(const py::array &theta_,
           double a_theta = deflect(i,0),
                  a_phi = deflect(i,1);
           double d = a_theta*a_theta + a_phi*a_phi;
+          double sin_aoa, twohav_aod, cos_a;
           if (d < 0.0025){ // largely covers all CMB-lensing relevant cases to double precision
             sin_aoa = 1. - d/6. * (1. - d/20. * (1. - d/42.));   // sin(a) / a
             twohav_aod = -0.5 + d/24. * (1. - d/30. * (1. - d/56.));   // (cos a - 1) / (a* a), also needed for rotation      

--- a/python/sht_pymod.cc
+++ b/python/sht_pymod.cc
@@ -47,6 +47,20 @@ namespace py = pybind11;
 
 auto None = py::none();
 
+SHT_mode get_mode(const string &smode)
+  {
+  if (smode=="STANDARD") return STANDARD;
+  if (smode=="GRAD_ONLY") return GRAD_ONLY;
+  if (smode=="DERIV1") return DERIV1;
+  MR_fail("unknown SHT mode");
+  }
+
+size_t get_nmaps(size_t spin, SHT_mode /*mode*/)
+  { return 1+(spin>0); }
+
+size_t get_nalm(size_t spin, SHT_mode mode)
+  { return (spin==0) ? 1 : ((mode==STANDARD) ? 2 : 1); }
+
 py::array Py_GL_weights(size_t nlat, size_t nlon)
   {
   auto res = make_Pyarr<double>({nlat});
@@ -185,8 +199,9 @@ size_t min_mapdim(const cmav<size_t,1> &nphi, const cmav<size_t,1> &ringstart,
 template<typename T> py::array Py2_alm2leg(const py::array &alm_, size_t spin,
   size_t lmax, const py::object &mval_, const py::object &mstart_,
   ptrdiff_t lstride, const py::array &theta_, size_t nthreads,
-  py::object &leg__)
+  py::object &leg__, const string &mode_)
   {
+  auto mode = get_mode(mode_);
   auto alm = to_cmav<complex<T>,2>(alm_);
   auto theta = to_cmav<double,1>(theta_);
   vmav<size_t,1> mval, mstart;
@@ -194,91 +209,64 @@ template<typename T> py::array Py2_alm2leg(const py::array &alm_, size_t spin,
   MR_assert(alm.shape(1)>=min_almdim(lmax, mval, mstart, lstride),
     "bad a_lm array size");
   auto leg_ = get_optional_Pyarr<complex<T>>(leg__,
-    {alm.shape(0),theta.shape(0),mval.shape(0)});
+    {get_nmaps(spin,mode),theta.shape(0),mval.shape(0)});
   auto leg = to_vmav<complex<T>,3>(leg_);
   {
   py::gil_scoped_release release;
-  alm2leg(alm, leg, spin, lmax, mval, mstart, lstride, theta, nthreads, ALM2MAP);
+  alm2leg(alm, leg, spin, lmax, mval, mstart, lstride, theta, nthreads, mode);
   }
   return leg_;
   }
 py::array Py_alm2leg(const py::array &alm, size_t lmax, const py::array &theta,
   size_t spin, const py::object &mval, const py::object &mstart,
-  ptrdiff_t lstride, size_t nthreads, py::object &leg)
+  ptrdiff_t lstride, size_t nthreads, py::object &leg, const string &mode)
   {
   if (isPyarr<complex<float>>(alm))
     return Py2_alm2leg<float>(alm, spin, lmax, mval, mstart, lstride, theta,
-      nthreads, leg);
+      nthreads, leg, mode);
   if (isPyarr<complex<double>>(alm))
     return Py2_alm2leg<double>(alm, spin, lmax, mval, mstart, lstride, theta,
-      nthreads, leg);
+      nthreads, leg, mode);
   MR_fail("type matching failed: 'alm' has neither type 'c8' nor 'c16'");
-  }
-template<typename T> py::array Py2_alm2leg_deriv1(const py::array &alm_,
-   size_t lmax, const py::object &mval_, const py::object &mstart_,
-   ptrdiff_t lstride, const py::array &theta_, size_t nthreads,
-   py::object &leg__)
-  {
-  auto alm = to_cmav<complex<T>,2>(alm_);
-  auto theta = to_cmav<double,1>(theta_);
-  vmav<size_t,1> mval, mstart;
-  getmstuff(lmax, mval_, mstart_, mval, mstart);
-  MR_assert(alm.shape(0)==1, "need exactly 1 a_lm component");
-  MR_assert(alm.shape(1)>=min_almdim(lmax, mval, mstart, lstride),
-    "bad a_lm array size");
-  auto leg_ = get_optional_Pyarr<complex<T>>(leg__,
-    {2,theta.shape(0),mval.shape(0)});
-  auto leg = to_vmav<complex<T>,3>(leg_);
-  {
-  py::gil_scoped_release release;
-  alm2leg(alm, leg, 0, lmax, mval, mstart, lstride, theta, nthreads,
-    ALM2MAP_DERIV1);
-  }
-  return leg_;
   }
 py::array Py_alm2leg_deriv1(const py::array &alm, size_t lmax,
   const py::array &theta, const py::object &mval, const py::object &mstart,
   ptrdiff_t lstride, size_t nthreads, py::object &leg)
   {
-  if (isPyarr<complex<float>>(alm))
-    return Py2_alm2leg_deriv1<float>(alm, lmax, mval, mstart, lstride, theta,
-      nthreads, leg);
-  if (isPyarr<complex<double>>(alm))
-    return Py2_alm2leg_deriv1<double>(alm, lmax, mval, mstart, lstride, theta,
-      nthreads, leg);
-  MR_fail("type matching failed: 'alm' has neither type 'c8' nor 'c16'");
+  return Py_alm2leg(alm, lmax, theta, 1, mval, mstart, lstride, nthreads, leg, "DERIV1");
   }
 template<typename T> py::array Py2_leg2alm(const py::array &leg_,
   const py::array &theta_, size_t spin, size_t lmax, const py::object &mval_,
   const py::object &mstart_, ptrdiff_t lstride, size_t nthreads,
-  py::object &alm__)
+  py::object &alm__,const string &mode_)
   {
+  auto mode = get_mode(mode_);
   auto leg = to_cmav<complex<T>,3>(leg_);
   auto theta = to_cmav<double,1>(theta_);
   MR_assert(leg.shape(1)==theta.shape(0), "bad leg array size");
   vmav<size_t,1> mval, mstart;
   getmstuff(lmax, mval_, mstart_, mval, mstart);
   auto alm_ = get_optional_Pyarr_minshape<complex<T>>(alm__,
-    {leg.shape(0),min_almdim(lmax, mval, mstart, lstride)});
+    {get_nalm(spin,mode),min_almdim(lmax, mval, mstart, lstride)});
   auto alm = to_vmav<complex<T>,2>(alm_);
   MR_assert(alm.shape(0)==leg.shape(0),
     "bad number of components in a_lm array");
   {
   py::gil_scoped_release release;
-  leg2alm(alm, leg, spin, lmax, mval, mstart, lstride, theta, nthreads);
+  leg2alm(alm, leg, spin, lmax, mval, mstart, lstride, theta, nthreads, mode);
   }
   return alm_;
   }
 py::array Py_leg2alm(const py::array &leg, size_t lmax, const py::array &theta,
   size_t spin, const py::object &mval, const py::object &mstart,
-  ptrdiff_t lstride, size_t nthreads, py::object &alm)
+  ptrdiff_t lstride, size_t nthreads, py::object &alm, const string &mode)
   {
   if (isPyarr<complex<float>>(leg))
     return Py2_leg2alm<float>(leg, theta, spin, lmax, mval, mstart, lstride,
-      nthreads, alm);
+      nthreads, alm, mode);
   if (isPyarr<complex<double>>(leg))
     return Py2_leg2alm<double>(leg, theta, spin, lmax, mval, mstart, lstride,
-      nthreads, alm);
+      nthreads, alm, mode);
   MR_fail("type matching failed: 'leg' has neither type 'c8' nor 'c16'");
   }
 template<typename T> py::array Py2_map2leg(const py::array &map_,
@@ -352,8 +340,10 @@ template<typename T> py::array Py2_synthesis(const py::array &alm_,
   const py::array &theta_,
   const py::array &nphi_,
   const py::array &phi0_, const py::array &ringstart_,
-  ptrdiff_t pixstride, size_t nthreads, const py::object &mmax_)
+  ptrdiff_t pixstride, size_t nthreads, const py::object &mmax_,
+  const string &mode_)
   {
+  auto mode = get_mode(mode_);
   auto mstart = get_mstart(lmax, mmax_, mstart_);
   auto theta = to_cmav<double,1>(theta_);
   auto phi0 = to_cmav<double,1>(phi0_);
@@ -364,10 +354,10 @@ template<typename T> py::array Py2_synthesis(const py::array &alm_,
   vector<size_t> mapshp(alm_.ndim());
   for(size_t i=0; i<mapshp.size(); ++i) mapshp[i] = alm_.shape()[i];
   mapshp[mapshp.size()-1] = min_mapdim(nphi, ringstart, pixstride);
+  mapshp[mapshp.size()-2] = get_nmaps(spin, mode);
   auto map_ = get_optional_Pyarr_minshape<T>(map__, mapshp);
   auto map = to_vmav_with_optional_leading_dimensions<T,3>(map_);
   MR_assert(map.shape(0)==alm.shape(0), "bad number of components in map array");
-  MR_assert(map.shape(1)==alm.shape(1), "bad number of components in map array");
   size_t nthreads_outer=1;
   if (alm.shape(0)>nthreads)  // parallelize over entire transforms
     { nthreads_outer=nthreads; nthreads=1; }
@@ -381,7 +371,7 @@ template<typename T> py::array Py2_synthesis(const py::array &alm_,
         auto subalm = subarray<2>(alm, {{itrans},{},{}});
         auto submap = subarray<2>(map, {{itrans},{},{}});
         synthesis(subalm, submap, spin, lmax, mstart, lstride, theta, nphi,
-          phi0, ringstart, pixstride, nthreads, ALM2MAP);
+          phi0, ringstart, pixstride, nthreads, mode);
         }
     });
   }
@@ -392,57 +382,15 @@ py::array Py_synthesis(const py::array &alm, const py::array &theta,
   const py::array &nphi,
   const py::array &phi0, const py::array &ringstart, size_t spin,
   ptrdiff_t lstride, ptrdiff_t pixstride, size_t nthreads, py::object &map,
-  const py::object &mmax_)
+  const py::object &mmax_, const string &mode)
   {
   if (isPyarr<complex<float>>(alm))
     return Py2_synthesis<float>(alm, map, spin, lmax, mstart, lstride, theta,
-      nphi, phi0, ringstart, pixstride, nthreads, mmax_);
+      nphi, phi0, ringstart, pixstride, nthreads, mmax_, mode);
   else if (isPyarr<complex<double>>(alm))
     return Py2_synthesis<double>(alm, map, spin, lmax, mstart, lstride, theta,
-      nphi, phi0, ringstart, pixstride, nthreads, mmax_);
+      nphi, phi0, ringstart, pixstride, nthreads, mmax_, mode);
   MR_fail("type matching failed: 'alm' has neither type 'c8' nor 'c16'");
-  }
-template<typename T> py::array Py2_synthesis_deriv1(const py::array &alm_,
-  py::object &map__, size_t lmax,
-  const py::object &mstart_, ptrdiff_t lstride,
-  const py::array &theta_,
-  const py::array &nphi_,
-  const py::array &phi0_, const py::array &ringstart_,
-  ptrdiff_t pixstride, size_t nthreads, const py::object &mmax_)
-  {
-  auto mstart = get_mstart(lmax, mmax_, mstart_);
-  auto theta = to_cmav<double,1>(theta_);
-  auto phi0 = to_cmav<double,1>(phi0_);
-  auto nphi = to_cmav<size_t,1>(nphi_);
-  auto ringstart = to_cmav<size_t,1>(ringstart_);
-  MR_assert((alm_.ndim()>=2)&&(alm_.ndim()<=3), "alm must be a 2D or 3D array");
-  auto alm = to_cmav_with_optional_leading_dimensions<complex<T>,3>(alm_);
-  vector<size_t> mapshp(alm_.ndim());
-  for(size_t i=0; i<mapshp.size(); ++i) mapshp[i] = alm_.shape()[i];
-  MR_assert(alm.shape(0)==1, "bad number of components in alm array");
-  mapshp[mapshp.size()-1] = min_mapdim(nphi, ringstart, pixstride);
-  mapshp[mapshp.size()-2] = 2;
-  auto map_ = get_optional_Pyarr_minshape<T>(map__, mapshp);
-  auto map = to_vmav_with_optional_leading_dimensions<T,3>(map_);
-  MR_assert(map.shape(0)==alm.shape(0), "bad number of components in map array");
-  size_t nthreads_outer=1;
-  if (alm.shape(0)>nthreads)  // parallelize over entire transforms
-    { nthreads_outer=nthreads; nthreads=1; }
-  {
-  py::gil_scoped_release release;
-  execDynamic(alm.shape(0), nthreads_outer, 1, [&](Scheduler &sched)
-    {
-    while (auto rng=sched.getNext())
-      for(auto itrans=rng.lo; itrans<rng.hi; ++itrans)
-        {
-        auto subalm = subarray<2>(alm, {{itrans},{},{}});
-        auto submap = subarray<2>(map, {{itrans},{},{}});
-        synthesis(subalm, submap, 1, lmax, mstart, lstride, theta, nphi, phi0,
-          ringstart, pixstride, nthreads, ALM2MAP_DERIV1);
-        }
-    });
-  }
-  return map_;
   }
 py::array Py_synthesis_deriv1(const py::array &alm, const py::array &theta,
   size_t lmax, const py::object &mstart,
@@ -450,13 +398,8 @@ py::array Py_synthesis_deriv1(const py::array &alm, const py::array &theta,
   const py::array &phi0, const py::array &ringstart, ptrdiff_t lstride, ptrdiff_t pixstride,
   size_t nthreads, py::object &map, const py::object &mmax_)
   {
-  if (isPyarr<complex<float>>(alm))
-    return Py2_synthesis_deriv1<float>(alm, map, lmax, mstart, lstride, theta,
-      nphi, phi0, ringstart, pixstride, nthreads, mmax_);
-  else if (isPyarr<complex<double>>(alm))
-    return Py2_synthesis_deriv1<double>(alm, map, lmax, mstart, lstride, theta,
-      nphi, phi0, ringstart, pixstride, nthreads, mmax_);
-  MR_fail("type matching failed: 'alm' has neither type 'c8' nor 'c16'");
+  return Py_synthesis(alm, theta, lmax, mstart, nphi, phi0, ringstart, 1, lstride,
+    pixstride, nthreads, map, mmax_, "DERIV1");
   }
 
 
@@ -501,92 +444,71 @@ template<typename T> py::array_t<complex<T>> check_build_alm
 
 template<typename T> py::array Py2_synthesis_2d(const py::array &alm_,
   size_t spin, size_t lmax, const string &geometry, const py::object & ntheta,
-  const py::object &nphi, size_t mmax, size_t nthreads, py::object &map__)
+  const py::object &nphi, size_t mmax, size_t nthreads, py::object &map__, const string &mode_)
   {
+  auto mode = get_mode(mode_);
   auto alm = to_cmav<complex<T>,2>(alm_);
-  auto map_ = check_build_map<T>(map__, alm.shape(0), ntheta, nphi);
+  auto map_ = check_build_map<T>(map__, get_nmaps(spin,mode), ntheta, nphi);
   auto map = to_vmav<T,3>(map_);
-  MR_assert(map.shape(0)==alm.shape(0), "bad number of components in map array");
   {
   py::gil_scoped_release release;
-  synthesis_2d(alm, map, spin, lmax, mmax, geometry, nthreads);
+  synthesis_2d(alm, map, spin, lmax, mmax, geometry, nthreads, mode);
   }
   return map_;
   }
 py::array Py_synthesis_2d(const py::array &alm, size_t spin, size_t lmax,
   const string &geometry, const py::object &ntheta, const py::object &nphi,
-  const py::object &mmax_, size_t nthreads, py::object &map)
+  const py::object &mmax_, size_t nthreads, py::object &map, const string &mode)
   {
   size_t mmax = mmax_.is_none() ? lmax : mmax_.cast<size_t>();
   if (isPyarr<complex<float>>(alm))
     return Py2_synthesis_2d<float>(alm, spin, lmax, geometry, ntheta, nphi,
-      mmax, nthreads, map);
+      mmax, nthreads, map, mode);
   else if (isPyarr<complex<double>>(alm))
     return Py2_synthesis_2d<double>(alm, spin, lmax, geometry, ntheta, nphi,
-      mmax, nthreads, map);
+      mmax, nthreads, map, mode);
   MR_fail("type matching failed: 'alm' has neither type 'c8' nor 'c16'");
   }
 template<typename T> py::array Py2_adjoint_synthesis_2d(
   const py::array &map_, size_t spin, size_t lmax, const string &geometry,
-  size_t mmax, size_t nthreads, py::object &alm__)
+  size_t mmax, size_t nthreads, py::object &alm__, const string &mode_)
   {
+  auto mode = get_mode(mode_);
   auto map = to_cmav<T,3>(map_);
-  auto alm_ = check_build_alm<T>(alm__, map.shape(0), lmax, mmax);
+  auto alm_ = check_build_alm<T>(alm__, get_nalm(spin,mode), lmax, mmax);
   auto alm = to_vmav<complex<T>,2>(alm_);
-  MR_assert(map.shape(0)==alm.shape(0), "bad number of components in map array");
   {
   py::gil_scoped_release release;
-  adjoint_synthesis_2d(alm, map, spin, lmax, mmax, geometry, nthreads);
+  adjoint_synthesis_2d(alm, map, spin, lmax, mmax, geometry, nthreads, mode);
   }
   return alm_;
   }
 py::array Py_adjoint_synthesis_2d(
   const py::array &map, size_t spin, size_t lmax, const string &geometry,
-  const py::object &mmax_, size_t nthreads, py::object &alm)
+  const py::object &mmax_, size_t nthreads, py::object &alm, const string &mode)
   {
   size_t mmax = mmax_.is_none() ? lmax : mmax_.cast<size_t>();
   if (isPyarr<float>(map))
     return Py2_adjoint_synthesis_2d<float>(map, spin, lmax, geometry, mmax,
-      nthreads, alm);
+      nthreads, alm,mode);
   else if (isPyarr<double>(map))
     return Py2_adjoint_synthesis_2d<double>(map, spin, lmax, geometry, mmax,
-      nthreads, alm);
+      nthreads, alm, mode);
   MR_fail("type matching failed: 'alm' has neither type 'c8' nor 'c16'");
-  }
-template<typename T> py::array Py2_synthesis_2d_deriv1(const py::array &alm_,
-  size_t lmax, const string &geometry, const py::object & ntheta,
-  const py::object &nphi, size_t mmax, size_t nthreads, py::object &map__)
-  {
-  auto alm = to_cmav<complex<T>,2>(alm_);
-  auto map_ = check_build_map<T>(map__, 2, ntheta, nphi);
-  auto map = to_vmav<T,3>(map_);
-  MR_assert((map.shape(0)==2) && (alm.shape(0)==1),
-    "incorrect number of components");
-  {
-  py::gil_scoped_release release;
-  synthesis_2d(alm, map, 1, lmax, mmax, geometry, nthreads, ALM2MAP_DERIV1);
-  }
-  return map_;
   }
 py::array Py_synthesis_2d_deriv1(const py::array &alm, size_t lmax,
   const string &geometry, const py::object &ntheta, const py::object &nphi, const py::object &mmax_, size_t nthreads, py::object &map)
   {
-  size_t mmax = mmax_.is_none() ? lmax : mmax_.cast<size_t>();
-  if (isPyarr<complex<float>>(alm))
-    return Py2_synthesis_2d_deriv1<float>(alm, lmax, geometry, ntheta, nphi,
-      mmax, nthreads, map);
-  else if (isPyarr<complex<double>>(alm))
-    return Py2_synthesis_2d_deriv1<double>(alm, lmax, geometry, ntheta, nphi,
-      mmax, nthreads, map);
-  MR_fail("type matching failed: 'alm' has neither type 'c8' nor 'c16'");
+  return Py_synthesis_2d(alm, 1, lmax, geometry, ntheta, nphi, mmax_, nthreads, map, "DERIV1");
   }
 
 template<typename T> py::array Py2_adjoint_synthesis(py::object &alm__,
   size_t lmax, const py::object &mstart_, ptrdiff_t lstride,
   const py::array &map_, const py::array &theta_, const py::array &phi0_,
   const py::array &nphi_, const py::array &ringstart_, size_t spin,
-  ptrdiff_t pixstride, size_t nthreads, const py::object &mmax_)
+  ptrdiff_t pixstride, size_t nthreads, const py::object &mmax_, const string &mode_)
   {
+  auto mode = get_mode(mode_);
   auto mstart = get_mstart(lmax, mmax_, mstart_);
   auto theta = to_cmav<double,1>(theta_);
   auto phi0 = to_cmav<double,1>(phi0_);
@@ -600,10 +522,10 @@ template<typename T> py::array Py2_adjoint_synthesis(py::object &alm__,
   vector<size_t> almshp(map_.ndim());
   for(size_t i=0; i<almshp.size(); ++i) almshp[i] = map_.shape()[i];
   almshp[almshp.size()-1] = min_almdim(lmax, mval, mstart, lstride);
+  almshp[almshp.size()-2] = get_nalm(spin, mode);
   auto alm_ = get_optional_Pyarr_minshape<complex<T>>(alm__, almshp);
   auto alm = to_vmav_with_optional_leading_dimensions<complex<T>,3>(alm_);
   MR_assert(map.shape(0)==alm.shape(0), "bad number of components in alm array");
-  MR_assert(map.shape(1)==alm.shape(1), "bad number of components in alm array");
   size_t nthreads_outer=1;
   if (map.shape(0)>nthreads)  // parallelize over entire transforms
     { nthreads_outer=nthreads; nthreads=1; }
@@ -617,7 +539,7 @@ template<typename T> py::array Py2_adjoint_synthesis(py::object &alm__,
         auto submap = subarray<2>(map, {{itrans},{},{}});
         auto subalm = subarray<2>(alm, {{itrans},{},{}});
         adjoint_synthesis(subalm, submap, spin, lmax, mstart, lstride, theta,
-          nphi, phi0, ringstart, pixstride, nthreads);
+          nphi, phi0, ringstart, pixstride, nthreads, mode);
         }
     });
   }
@@ -630,14 +552,15 @@ py::array Py_adjoint_synthesis(const py::array &map, const py::array &theta,
   const py::array &phi0, const py::array &ringstart, size_t spin,
   ptrdiff_t lstride, ptrdiff_t pixstride,
   size_t nthreads,
-  py::object &alm, const py::object &mmax_)
+  py::object &alm, const py::object &mmax_,
+  const string &mode)
   {
   if (isPyarr<float>(map))
     return Py2_adjoint_synthesis<float>(alm, lmax, mstart, lstride, map, theta,
-      phi0, nphi, ringstart, spin, pixstride, nthreads, mmax_);
+      phi0, nphi, ringstart, spin, pixstride, nthreads, mmax_, mode);
   else if (isPyarr<double>(map))
     return Py2_adjoint_synthesis<double>(alm, lmax, mstart, lstride, map, theta,
-      phi0, nphi, ringstart, spin, pixstride, nthreads, mmax_);
+      phi0, nphi, ringstart, spin, pixstride, nthreads, mmax_, mode);
   MR_fail("type matching failed: 'alm' has neither type 'c8' nor 'c16'");
   }
 template<typename T> py::object Py2_pseudo_analysis(py::object &alm__,
@@ -781,32 +704,32 @@ py::array Py_adjoint_analysis_2d(const py::array &alm, size_t spin, size_t lmax,
 
 template<typename T, typename Tloc> py::array Py2_synthesis_general(const py::array &alm_,
   size_t spin, size_t lmax, const py::array &loc_, double epsilon, size_t mmax,
-  size_t nthreads, py::object &map__, double sigma_min, double sigma_max)
+  size_t nthreads, py::object &map__, double sigma_min, double sigma_max, const string &mode_)
   {
+  auto mode = get_mode(mode_);
   auto alm = to_cmav<complex<T>,2>(alm_);
   auto loc = to_cmav<Tloc,2>(loc_);
   MR_assert(loc.shape(1)==2, "last dimension of loc must have size 2");
-  size_t ncomp = (spin==0) ? 1 : 2;
-  MR_assert(alm.shape(0)==ncomp, "number of components mismatch in alm");
-  auto map_ = get_optional_Pyarr<T>(map__, {alm.shape(0), loc.shape(0)});
+  MR_assert(alm.shape(0)==get_nalm(spin,mode), "number of components mismatch in alm");
+  auto map_ = get_optional_Pyarr<T>(map__, {get_nmaps(spin,mode), loc.shape(0)});
   auto map = to_vmav<T,2>(map_);
   {
   py::gil_scoped_release release;
-  synthesis_general(alm, map, spin, lmax, mmax, loc, epsilon, sigma_min, sigma_max, nthreads);
+  synthesis_general(alm, map, spin, lmax, mmax, loc, epsilon, sigma_min, sigma_max, nthreads, mode);
   }
   return map_;
   }
 py::array Py_synthesis_general(const py::array &alm, size_t spin, size_t lmax,
   const py::array &loc, double epsilon, const py::object &mmax_,
-  size_t nthreads, py::object &map, double sigma_min, double sigma_max)
+  size_t nthreads, py::object &map, double sigma_min, double sigma_max, const string &mode)
   {
   size_t mmax = mmax_.is_none() ? lmax : mmax_.cast<size_t>();
   if (isPyarr<double>(loc))
     {
     if (isPyarr<complex<float>>(alm))
-      return Py2_synthesis_general<float,double>(alm, spin, lmax, loc, epsilon, mmax, nthreads, map, sigma_min, sigma_max);
+      return Py2_synthesis_general<float,double>(alm, spin, lmax, loc, epsilon, mmax, nthreads, map, sigma_min, sigma_max, mode);
     else if (isPyarr<complex<double>>(alm))
-      return Py2_synthesis_general<double,double>(alm, spin, lmax, loc, epsilon, mmax, nthreads, map, sigma_min, sigma_max);
+      return Py2_synthesis_general<double,double>(alm, spin, lmax, loc, epsilon, mmax, nthreads, map, sigma_min, sigma_max, mode);
    }
 #if 0
   else if (isPyarr<float>(loc))
@@ -823,33 +746,33 @@ py::array Py_synthesis_general(const py::array &alm, size_t spin, size_t lmax,
 
 template<typename T, typename Tloc> py::array Py2_adjoint_synthesis_general(const py::array &map_,
   size_t spin, size_t lmax, const py::array &loc_, double epsilon, size_t mmax,
-  size_t nthreads, py::object &alm__, double sigma_min, double sigma_max)
+  size_t nthreads, py::object &alm__, double sigma_min, double sigma_max, const string &mode_)
   {
+  auto mode = get_mode(mode_);
   auto map = to_cmav<T,2>(map_);
   auto loc = to_cmav<Tloc,2>(loc_);
   MR_assert(loc.shape(1)==2, "last dimension of loc must have size 2");
-  size_t ncomp = (spin==0) ? 1 : 2;
-  MR_assert(map.shape(0)==ncomp, "number of components mismatch in map");
-  auto alm_ = check_build_alm<T>(alm__, map.shape(0), lmax, mmax);
+  MR_assert(map.shape(0)==get_nmaps(spin,mode), "number of components mismatch in map");
+  auto alm_ = check_build_alm<T>(alm__, get_nalm(spin,mode), lmax, mmax);
   auto alm = to_vmav<complex<T>,2>(alm_);
 
   {
   py::gil_scoped_release release;
-  adjoint_synthesis_general(alm, map, spin, lmax, mmax, loc, epsilon, sigma_min, sigma_max, nthreads);
+  adjoint_synthesis_general(alm, map, spin, lmax, mmax, loc, epsilon, sigma_min, sigma_max, nthreads, mode);
   }
   return alm_;
   }
 py::array Py_adjoint_synthesis_general(const py::array &map, size_t spin, size_t lmax,
   const py::array &loc, double epsilon, const py::object &mmax_,
-  size_t nthreads, py::object &alm, double sigma_min, double sigma_max)
+  size_t nthreads, py::object &alm, double sigma_min, double sigma_max, const string &mode)
   {
   size_t mmax = mmax_.is_none() ? lmax : mmax_.cast<size_t>();
   if (isPyarr<double>(loc))
     {
     if (isPyarr<float>(map))
-      return Py2_adjoint_synthesis_general<float,double>(map, spin, lmax, loc, epsilon, mmax, nthreads, alm, sigma_min, sigma_max);
+      return Py2_adjoint_synthesis_general<float,double>(map, spin, lmax, loc, epsilon, mmax, nthreads, alm, sigma_min, sigma_max, mode);
     else if (isPyarr<double>(map))
-      return Py2_adjoint_synthesis_general<double,double>(map, spin, lmax, loc, epsilon, mmax, nthreads, alm, sigma_min, sigma_max);
+      return Py2_adjoint_synthesis_general<double,double>(map, spin, lmax, loc, epsilon, mmax, nthreads, alm, sigma_min, sigma_max, mode);
     }
 #if 0
   else if (isPyarr<float>(loc))
@@ -1019,13 +942,13 @@ template<typename T> class Py_sharpjob
           ringstart(rs) = size_t(base.Npix() - startpix - ringpix);
           }
         vmav<double,2> mr(map.data(), {1, size_t(npix_)}, {0, map.stride(0)});
-        synthesis(ar, mr, 0, lmax_, mstart, 1, theta, nphi, phi0, ringstart, 1, nthreads);
+        synthesis(ar, mr, 0, lmax_, mstart, 1, theta, nphi, phi0, ringstart, 1, nthreads, STANDARD);
         }
       else
         {
         vmav<double,3> mr(map.data(), {1, size_t(ntheta_), size_t(nphi_)},
           {0, ptrdiff_t(map.stride(0)*nphi_), map.stride(0)});
-        synthesis_2d(ar, mr, 0, lmax_, mmax_, geom, nthreads);
+        synthesis_2d(ar, mr, 0, lmax_, mmax_, geom, nthreads, STANDARD);
         }
       return map_;
       }
@@ -1059,13 +982,13 @@ template<typename T> class Py_sharpjob
           ringstart(rs) = size_t(base.Npix() - startpix - ringpix);
           }
         cmav<double,2> mr(map.data(), {1, npix_}, {0, map.stride(0)});
-        adjoint_synthesis(ar, mr, 0, lmax_, mstart, 1, theta, nphi, phi0, ringstart, 1, nthreads);
+        adjoint_synthesis(ar, mr, 0, lmax_, mstart, 1, theta, nphi, phi0, ringstart, 1, nthreads,STANDARD);
         }
       else
         {
         cmav<double,3> mr(map.data(), {1, size_t(ntheta_), size_t(nphi_)},
           {0, ptrdiff_t(map.stride(0)*nphi_), map.stride(0)});
-        adjoint_synthesis_2d(ar, mr, 0, lmax_, mmax_, geom, nthreads);
+        adjoint_synthesis_2d(ar, mr, 0, lmax_, mmax_, geom, nthreads, STANDARD);
         }
       return alm_;
       }
@@ -1111,13 +1034,13 @@ template<typename T> class Py_sharpjob
           ringstart(r) = size_t(startpix);
           ringstart(rs) = size_t(base.Npix() - startpix - ringpix);
           }
-        synthesis(alm, map, spin, lmax_, mstart, 1, theta, nphi, phi0, ringstart, 1, nthreads);
+        synthesis(alm, map, spin, lmax_, mstart, 1, theta, nphi, phi0, ringstart, 1, nthreads, STANDARD);
         }
       else
         {
         vmav<double,3> mr(map.data(), {2, ntheta_, nphi_},
           {map.stride(0), ptrdiff_t(map.stride(1)*nphi_), map.stride(1)});
-        synthesis_2d(alm, mr, spin, lmax_, mmax_, geom, nthreads);
+        synthesis_2d(alm, mr, spin, lmax_, mmax_, geom, nthreads, STANDARD);
         }
       return map_;
       }
@@ -2033,10 +1956,10 @@ void add_sht(py::module_ &msup)
 
   m2.def("synthesis", &Py_synthesis, synthesis_DS, py::kw_only(), "alm"_a, "theta"_a,
     "lmax"_a, "mstart"_a=None, "nphi"_a, "phi0"_a, "ringstart"_a, "spin"_a,
-    "lstride"_a=1, "pixstride"_a=1, "nthreads"_a=1, "map"_a=None, "mmax"_a=None);
+    "lstride"_a=1, "pixstride"_a=1, "nthreads"_a=1, "map"_a=None, "mmax"_a=None, "mode"_a="STANDARD");
   m2.def("adjoint_synthesis", &Py_adjoint_synthesis, adjoint_synthesis_DS, py::kw_only(), "map"_a, "theta"_a,
     "lmax"_a, "mstart"_a=None, "nphi"_a, "phi0"_a, "ringstart"_a, "spin"_a,
-    "lstride"_a=1, "pixstride"_a=1, "nthreads"_a=1, "alm"_a=None, "mmax"_a=None);
+    "lstride"_a=1, "pixstride"_a=1, "nthreads"_a=1, "alm"_a=None, "mmax"_a=None, "mode"_a="STANDARD");
   m2.def("pseudo_analysis", &Py_pseudo_analysis, pseudo_analysis_DS, py::kw_only(), "map"_a, "theta"_a,
     "lmax"_a, "mstart"_a=None, "nphi"_a, "phi0"_a, "ringstart"_a, "spin"_a,
     "lstride"_a=1, "pixstride"_a=1, "nthreads"_a=1, "alm"_a=None, "maxiter"_a, "epsilon"_a, "mmax"_a=None);
@@ -2044,23 +1967,23 @@ void add_sht(py::module_ &msup)
     "lmax"_a, "mstart"_a=None, "nphi"_a, "phi0"_a, "ringstart"_a,
     "lstride"_a=1, "pixstride"_a=1, "nthreads"_a=1, "map"_a=None, "mmax"_a=None);
 
-  m2.def("synthesis_2d", &Py_synthesis_2d, synthesis_2d_DS, py::kw_only(), "alm"_a, "spin"_a, "lmax"_a, "geometry"_a, "ntheta"_a=None, "nphi"_a=None, "mmax"_a=None, "nthreads"_a=1, "map"_a=None);
-  m2.def("adjoint_synthesis_2d", &Py_adjoint_synthesis_2d, adjoint_synthesis_2d_DS, py::kw_only(), "map"_a, "spin"_a, "lmax"_a, "geometry"_a, "mmax"_a=None, "nthreads"_a=1, "alm"_a=None);
+  m2.def("synthesis_2d", &Py_synthesis_2d, synthesis_2d_DS, py::kw_only(), "alm"_a, "spin"_a, "lmax"_a, "geometry"_a, "ntheta"_a=None, "nphi"_a=None, "mmax"_a=None, "nthreads"_a=1, "map"_a=None, "mode"_a="STANDARD");
+  m2.def("adjoint_synthesis_2d", &Py_adjoint_synthesis_2d, adjoint_synthesis_2d_DS, py::kw_only(), "map"_a, "spin"_a, "lmax"_a, "geometry"_a, "mmax"_a=None, "nthreads"_a=1, "alm"_a=None, "mode"_a="STANDARD");
   m2.def("synthesis_2d_deriv1", &Py_synthesis_2d_deriv1, synthesis_2d_deriv1_DS, py::kw_only(), "alm"_a, "lmax"_a, "geometry"_a, "ntheta"_a=None, "nphi"_a=None, "mmax"_a=None, "nthreads"_a=1, "map"_a=None);
   m2.def("analysis_2d", &Py_analysis_2d, analysis_2d_DS, py::kw_only(), "map"_a, "spin"_a, "lmax"_a, "geometry"_a, "mmax"_a=None, "nthreads"_a=1, "alm"_a=None);
   m2.def("adjoint_analysis_2d", &Py_adjoint_analysis_2d, adjoint_analysis_2d_DS, py::kw_only(), "alm"_a, "spin"_a, "lmax"_a, "geometry"_a, "ntheta"_a=None, "nphi"_a=None, "mmax"_a=None, "nthreads"_a=1, "map"_a=None);
 
   // FIXME: maybe add mstart, lstride
-  m2.def("synthesis_general", &Py_synthesis_general, synthesis_general_DS, py::kw_only(), "alm"_a, "spin"_a, "lmax"_a, "loc"_a, "epsilon"_a=1e-5, "mmax"_a=None, "nthreads"_a=1, "map"_a=None, "sigma_min"_a=1.1, "sigma_max"_a=2.6);
-  m2.def("adjoint_synthesis_general", &Py_adjoint_synthesis_general, adjoint_synthesis_general_DS, py::kw_only(), "map"_a, "spin"_a, "lmax"_a, "loc"_a, "epsilon"_a=1e-5, "mmax"_a=None, "nthreads"_a=1, "alm"_a=None, "sigma_min"_a=1.1, "sigma_max"_a=2.6);
+  m2.def("synthesis_general", &Py_synthesis_general, synthesis_general_DS, py::kw_only(), "alm"_a, "spin"_a, "lmax"_a, "loc"_a, "epsilon"_a=1e-5, "mmax"_a=None, "nthreads"_a=1, "map"_a=None, "sigma_min"_a=1.1, "sigma_max"_a=2.6, "mode"_a="STANDARD");
+  m2.def("adjoint_synthesis_general", &Py_adjoint_synthesis_general, adjoint_synthesis_general_DS, py::kw_only(), "map"_a, "spin"_a, "lmax"_a, "loc"_a, "epsilon"_a=1e-5, "mmax"_a=None, "nthreads"_a=1, "alm"_a=None, "sigma_min"_a=1.1, "sigma_max"_a=2.6, "mode"_a="STANDARD");
   m2.def("pseudo_analysis_general", &Py_pseudo_analysis_general, pseudo_analysis_general_DS, py::kw_only(), "lmax"_a, "map"_a, "loc"_a, "spin"_a, "nthreads"_a, "maxiter"_a, "epsilon"_a=1e-5, "sigma_min"_a=1.1, "sigma_max"_a=2.6, "mmax"_a=None, "alm"_a=None);
 
   m2.def("GL_weights",&Py_GL_weights, "nlat"_a, "nlon"_a);
   m2.def("GL_thetas",&Py_GL_thetas, "nlat"_a);
   m2.def("get_gridweights", &Py_get_gridweights, "type"_a, "ntheta"_a);
-  m2.def("alm2leg", &Py_alm2leg, alm2leg_DS, py::kw_only(), "alm"_a, "lmax"_a, "theta"_a, "spin"_a=0, "mval"_a=None, "mstart"_a=None, "lstride"_a=1, "nthreads"_a=1, "leg"_a=None);
+  m2.def("alm2leg", &Py_alm2leg, alm2leg_DS, py::kw_only(), "alm"_a, "lmax"_a, "theta"_a, "spin"_a=0, "mval"_a=None, "mstart"_a=None, "lstride"_a=1, "nthreads"_a=1, "leg"_a=None, "mode"_a="STANDARD");
   m2.def("alm2leg_deriv1", &Py_alm2leg_deriv1, alm2leg_deriv1_DS, py::kw_only(), "alm"_a, "lmax"_a, "theta"_a, "mval"_a=None, "mstart"_a=None, "lstride"_a=1, "nthreads"_a=1, "leg"_a=None);
-  m2.def("leg2alm", &Py_leg2alm, leg2alm_DS, py::kw_only(), "leg"_a, "lmax"_a, "theta"_a, "spin"_a=0, "mval"_a=None, "mstart"_a=None, "lstride"_a=1, "nthreads"_a=1, "alm"_a=None);
+  m2.def("leg2alm", &Py_leg2alm, leg2alm_DS, py::kw_only(), "leg"_a, "lmax"_a, "theta"_a, "spin"_a=0, "mval"_a=None, "mstart"_a=None, "lstride"_a=1, "nthreads"_a=1, "alm"_a=None, "mode"_a="STANDARD");
   m2.def("map2leg", &Py_map2leg, map2leg_DS, py::kw_only(), "map"_a, "nphi"_a, "phi0"_a, "ringstart"_a, "mmax"_a, "pixstride"_a=1, "nthreads"_a=1, "leg"_a=None);
   m2.def("leg2map", &Py_leg2map, leg2map_DS, py::kw_only(), "leg"_a, "nphi"_a, "phi0"_a, "ringstart"_a, "pixstride"_a=1, "nthreads"_a=1, "map"_a=None);
   m.def("rotate_alm", &Py_rotate_alm, rotate_alm_DS, "alm"_a, "lmax"_a, "psi"_a, "theta"_a,

--- a/python/test/test_sht.py
+++ b/python/test/test_sht.py
@@ -131,6 +131,19 @@ def test_2d_adjoint(lmmax, geometry, spin, nthreads):
     v1 = np.sum([myalmdot(alm0[i], alm1[i], lmax) for i in range(ncomp)])
     assert_(np.abs((v1-v2)/v1)<1e-10)
 
+    if spin > 0:
+        # test adjointness between synthesis and adjoint_synthesis
+        map1 = ducc0.sht.experimental.synthesis_2d(alm=alm0[:1], lmax=lmax, mmax=mmax, spin=spin, ntheta=nrings, nphi=nphi, nthreads=nthreads, geometry=geometry, mode="GRAD_ONLY")
+        v2 = np.sum([ducc0.misc.vdot(map0[i], map1[i]) for i in range(ncomp)])
+        almx = alm0.copy()
+        almx[1] = 0
+        map1b = ducc0.sht.experimental.synthesis_2d(alm=almx, lmax=lmax, mmax=mmax, spin=spin, ntheta=nrings, nphi=nphi, nthreads=nthreads, geometry=geometry)
+        assert_(ducc0.misc.l2error(map1, map1b)<1e-10)
+        del almx, map1
+        alm1 = ducc0.sht.experimental.adjoint_synthesis_2d(lmax=lmax, mmax=mmax, spin=spin, map=map0, nthreads=nthreads, geometry=geometry, mode="GRAD_ONLY")
+        v1 = np.sum([myalmdot(alm0[i], alm1[i], lmax) for i in range(1)])
+        assert_(np.abs((v1-v2)/v1)<1e-10)
+
     # test adjointness between analysis and adjoint_analysis
 
     # naive version
@@ -189,6 +202,14 @@ def test_healpix_adjoint(lmax, nside, spin, mmaxhalf, nthreads):
     v1 = np.sum([myalmdot(alm0[i], alm1[i], lmax) for i in range(ncomp)])
     assert_(np.abs((v1-v2)/v1)<1e-10)
 
+    if spin > 0:
+        map1 = ducc0.sht.experimental.synthesis(alm=alm0[:1], lmax=lmax, spin=spin, nthreads=nthreads, mmax=mmax, mode="GRAD_ONLY", **geom)
+        v2 = np.sum([ducc0.misc.vdot(map0[i], map1[i]) for i in range(ncomp)])
+        del map1
+        alm1 = ducc0.sht.experimental.adjoint_synthesis(lmax=lmax, spin=spin, map=map0, nthreads=nthreads, mmax=mmax, mode="GRAD_ONLY", **geom)
+        v1 = np.sum([myalmdot(alm0[i], alm1[i], lmax) for i in range(1)])
+        assert_(np.abs((v1-v2)/v1)<1e-10)
+
 
 @pmp("lmax", tuple(range(0,70,3)))
 @pmp("nthreads", (0,1,2))
@@ -243,15 +264,21 @@ def test_adjointness_general(lmmax, npix, spin, nthreads):
     loc = rng.uniform(0., 1., (npix,2))
     loc[:, 0] *= np.pi
     loc[:, 1] *= 2*np.pi
-    points1 = ducc0.sht.experimental.synthesis_general(lmax=lmax, mmax=mmax, alm=slm1, loc=loc, spin=spin, epsilon=epsilon, nthreads=nthreads)
     points2 = rng.uniform(-0.5, 0.5, (loc.shape[0],ncomp)).T
+    points1 = ducc0.sht.experimental.synthesis_general(lmax=lmax, mmax=mmax, alm=slm1, loc=loc, spin=spin, epsilon=epsilon, nthreads=nthreads)
     slm2 = ducc0.sht.experimental.adjoint_synthesis_general(lmax=lmax, mmax=mmax, map=points2, loc=loc, spin=spin, epsilon=epsilon, nthreads=nthreads)
-    print(slm1.shape, slm2.shape)
     v1 = np.sum([myalmdot(slm1[c, :], slm2[c, :], lmax)
                 for c in range(ncomp)])
     v2 = ducc0.misc.vdot(points2.real, points1.real) + ducc0.misc.vdot(points2.imag, points1.imag) 
     assert_allclose(v1, v2, rtol=1e-9)
 
+    if spin > 0:
+        points1 = ducc0.sht.experimental.synthesis_general(lmax=lmax, mmax=mmax, alm=slm1[:1], loc=loc, spin=spin, epsilon=epsilon, nthreads=nthreads, mode="GRAD_ONLY")
+        slm2 = ducc0.sht.experimental.adjoint_synthesis_general(lmax=lmax, mmax=mmax, map=points2, loc=loc, spin=spin, epsilon=epsilon, nthreads=nthreads, mode="GRAD_ONLY")
+        v1 = np.sum([myalmdot(slm1[c, :], slm2[c, :], lmax)
+                    for c in range(1)])
+        v2 = ducc0.misc.vdot(points2.real, points1.real) + ducc0.misc.vdot(points2.imag, points1.imag) 
+        assert_allclose(v1, v2, rtol=1e-9)
 
 @pmp('spin', (0, 1, 2))
 @pmp('nthreads', (1, 4))

--- a/python/test/test_sht.py
+++ b/python/test/test_sht.py
@@ -132,9 +132,10 @@ def test_2d_adjoint(lmmax, geometry, spin, nthreads):
     assert_(np.abs((v1-v2)/v1)<1e-10)
 
     if spin > 0:
-        # test adjointness between synthesis and adjoint_synthesis
+        # test adjointness between synthesis and adjoint_synthesis (gradient only)
         map1 = ducc0.sht.experimental.synthesis_2d(alm=alm0[:1], lmax=lmax, mmax=mmax, spin=spin, ntheta=nrings, nphi=nphi, nthreads=nthreads, geometry=geometry, mode="GRAD_ONLY")
         v2 = np.sum([ducc0.misc.vdot(map0[i], map1[i]) for i in range(ncomp)])
+        # compare grad-only alm2map with full alm2map where curl is set to zero
         almx = alm0.copy()
         almx[1] = 0
         map1b = ducc0.sht.experimental.synthesis_2d(alm=almx, lmax=lmax, mmax=mmax, spin=spin, ntheta=nrings, nphi=nphi, nthreads=nthreads, geometry=geometry)

--- a/src/ducc0/sht/sht.h
+++ b/src/ducc0/sht/sht.h
@@ -37,10 +37,7 @@ namespace detail_sht {
 
 using namespace std;
 
-enum SHT_mode { MAP2ALM,
-                ALM2MAP,
-                ALM2MAP_DERIV1
-              };
+enum SHT_mode { STANDARD, GRAD_ONLY, DERIV1 };
 
 void get_gridweights(const string &type, vmav<double,1> &wgt);
 vmav<double,1> get_gridweights(const string &type, size_t nrings);
@@ -55,7 +52,7 @@ template<typename T> void alm2leg(  // associated Legendre transform
   ptrdiff_t lstride,
   const cmav<double,1> &theta, // (nrings)
   size_t nthreads,
-  SHT_mode mode=ALM2MAP);
+  SHT_mode mode);
 template<typename T> void leg2alm(  // associated Legendre transform
   vmav<complex<T>,2> &alm, // (ncomp, lmidx)
   const cmav<complex<T>,3> &leg, // (ncomp, nrings, nm)
@@ -65,7 +62,8 @@ template<typename T> void leg2alm(  // associated Legendre transform
   const cmav<size_t,1> &mstart, // (nm)
   ptrdiff_t lstride,
   const cmav<double,1> &theta, // (nrings)
-  size_t nthreads);
+  size_t nthreads,
+  SHT_mode mode);
 
 template<typename T> void map2leg(  // FFT
   const cmav<T,2> &map, // (ncomp, pix)
@@ -97,7 +95,7 @@ template<typename T> void synthesis(
   const cmav<size_t,1> &ringstart, // (nrings)
   ptrdiff_t pixstride,
   size_t nthreads,
-  SHT_mode mode=ALM2MAP);
+  SHT_mode mode);
 
 template<typename T> void adjoint_synthesis(
   vmav<complex<T>,2> &alm, // (ncomp, *)
@@ -111,7 +109,8 @@ template<typename T> void adjoint_synthesis(
   const cmav<double,1> &phi0, // (nrings)
   const cmav<size_t,1> &ringstart, // (nrings)
   ptrdiff_t pixstride,
-  size_t nthreads);
+  size_t nthreads,
+  SHT_mode mode);
 
 template<typename T> tuple<size_t, size_t, double, double> pseudo_analysis(
   vmav<complex<T>,2> &alm, // (ncomp, *)
@@ -127,14 +126,14 @@ template<typename T> tuple<size_t, size_t, double, double> pseudo_analysis(
   ptrdiff_t pixstride,
   size_t nthreads,
   size_t maxiter,
-  double epsilom);
+  double epsilon);
 
 template<typename T> void synthesis_2d(const cmav<complex<T>,2> &alm, vmav<T,3> &map,
-  size_t spin, size_t lmax, size_t mmax, const string &geometry, size_t nthreads, SHT_mode mode=ALM2MAP);
+  size_t spin, size_t lmax, size_t mmax, const string &geometry, size_t nthreads, SHT_mode mode);
 
 template<typename T> void adjoint_synthesis_2d(vmav<complex<T>,2> &alm,
   const cmav<T,3> &map, size_t spin, size_t lmax, size_t mmax,
-  const string &geometry, size_t nthreads);
+  const string &geometry, size_t nthreads, SHT_mode mode);
 
 template<typename T> void analysis_2d(vmav<complex<T>,2> &alm,
   const cmav<T,3> &map, size_t spin, size_t lmax, size_t mmax,
@@ -147,12 +146,12 @@ template<typename T> void adjoint_analysis_2d(const cmav<complex<T>,2> &alm,
 template<typename T, typename Tloc> void synthesis_general(
   const cmav<complex<T>,2> &alm, vmav<T,2> &map,
   size_t spin, size_t lmax, size_t mmax, const cmav<Tloc,2> &loc,
-  double epsilon, double sigma_min, double sigma_max, size_t nthreads);
+  double epsilon, double sigma_min, double sigma_max, size_t nthreads, SHT_mode mode);
 
 template<typename T, typename Tloc> void adjoint_synthesis_general(
   vmav<complex<T>,2> &alm, const cmav<T,2> &map,
   size_t spin, size_t lmax, size_t mmax, const cmav<Tloc,2> &loc,
-  double epsilon, double sigma_min, double sigma_max, size_t nthreads);
+  double epsilon, double sigma_min, double sigma_max, size_t nthreads, SHT_mode mode);
 
 template<typename T> tuple<size_t, size_t, double, double> pseudo_analysis_general(
   vmav<complex<T>,2> &alm, // (ncomp, *)
@@ -168,9 +167,9 @@ template<typename T> tuple<size_t, size_t, double, double> pseudo_analysis_gener
 }
 
 using detail_sht::SHT_mode;
-using detail_sht::ALM2MAP;
-using detail_sht::ALM2MAP_DERIV1;
-using detail_sht::MAP2ALM;
+using detail_sht::STANDARD;
+using detail_sht::GRAD_ONLY;
+using detail_sht::DERIV1;
 using detail_sht::get_gridweights;
 using detail_sht::alm2leg;
 using detail_sht::leg2alm;

--- a/src/ducc0/sht/sphere_interpol.h
+++ b/src/ducc0/sht/sphere_interpol.h
@@ -643,11 +643,9 @@ template<typename T> class SphereInterpol
       return res;
       }
 
-    void getPlane(const cmav<complex<T>,2> &valm, vmav<T,3> &planes) const
+    void getPlane(const cmav<complex<T>,2> &valm, vmav<T,3> &planes, SHT_mode mode) const
       {
       size_t nplanes=1+(spin>0);
-      auto ncomp = valm.shape(0);
-      MR_assert(ncomp==nplanes, "number of components mismatch");
       Alm_Base ialm(lmax, mmax);
       MR_assert(ialm.Num_Alms()==valm.shape(1), "bad array dimension");
       MR_assert(planes.conformable({nplanes, Ntheta(), Nphi()}), "bad planes shape");
@@ -659,7 +657,7 @@ template<typename T> class SphereInterpol
       MR_assert((planes.stride(0)&1)==0, "stride must be even");
       MR_assert(2*(mmax+1)<=nphi_b, "aargh");
       vmav<complex<T>,3> leg(reinterpret_cast<complex<T> *>(&planes(0,nbtheta,nbphi-1)),
-        {ncomp, ntheta_s, mmax+1}, {subplanes.stride(0)/2, subplanes.stride(1)/2, 1});
+        {nplanes, ntheta_s, mmax+1}, {subplanes.stride(0)/2, subplanes.stride(1)/2, 1});
       vmav<double,1> theta({ntheta_s}, UNINITIALIZED);
       for (size_t i=0; i<ntheta_s; ++i)
         theta(i) = (i*pi)/(ntheta_s-1);
@@ -672,7 +670,7 @@ template<typename T> class SphereInterpol
         mstart(i) = ofs-i;
         ofs += lmax+1-i;
         }
-      alm2leg(valm, leg, spin, lmax, mval, mstart, 1, theta, nthreads);
+      alm2leg(valm, leg, spin, lmax, mval, mstart, 1, theta, nthreads, mode);
       // make halfcomplex
       for (size_t iplane=0; iplane<nplanes; ++iplane)
         for (size_t itheta=0; itheta<ntheta_s; ++itheta)
@@ -731,11 +729,9 @@ template<typename T> class SphereInterpol
       deinterpolx<maxsupp>(kernel->support(), cube, itheta0, iphi0, theta, phi, signal);
       }
 
-    void updateAlm(vmav<complex<T>,2> &valm, vmav<T,3> &planes) const
+    void updateAlm(vmav<complex<T>,2> &valm, vmav<T,3> &planes, SHT_mode mode) const
       {
       size_t nplanes=1+(spin>0);
-      auto ncomp = valm.shape(0);
-      MR_assert(ncomp>0, "need at least one component");
       Alm_Base ialm(lmax, mmax);
       MR_assert(ialm.Num_Alms()==valm.shape(1), "bad array dimension");
       MR_assert(planes.conformable({nplanes, Ntheta(), Nphi()}), "bad planes shape");
@@ -785,7 +781,7 @@ template<typename T> class SphereInterpol
       MR_assert((planes.stride(0)&1)==0, "stride must be even");
       MR_assert(2*(mmax+1)<=nphi_b, "aargh");
       vmav<complex<T>,3> leg(reinterpret_cast<complex<T> *>(&planes(0,nbtheta,nbphi-1)),
-        {ncomp, ntheta_s, mmax+1}, {subplanes.stride(0)/2, subplanes.stride(1)/2, 1});
+        {nplanes, ntheta_s, mmax+1}, {subplanes.stride(0)/2, subplanes.stride(1)/2, 1});
       vmav<double,1> theta({ntheta_s}, UNINITIALIZED);
       for (size_t i=0; i<ntheta_s; ++i)
         theta(i) = (i*pi)/(ntheta_s-1);
@@ -806,13 +802,13 @@ template<typename T> class SphereInterpol
           planes(iplane, nbtheta+itheta, nbphi-1) = planes(iplane, nbtheta+itheta, nbphi);
           planes(iplane, nbtheta+itheta, nbphi) = T(0);
           }
-      leg2alm(valm, leg, spin, lmax, mval, mstart, 1, theta, nthreads);
+      leg2alm(valm, leg, spin, lmax, mval, mstart, 1, theta, nthreads, mode);
       }
 
-    void updateAlm(vmav<complex<T>,1> &alm, vmav<T,3> &planes) const
+    void updateAlm(vmav<complex<T>,1> &alm, vmav<T,3> &planes, SHT_mode mode) const
       {
       vmav<complex<T>,2> valm(alm.data(), {1,alm.shape(0)}, {0,alm.stride(0)});
-      updateAlm(valm, planes);
+      updateAlm(valm, planes, mode);
       }
   };
 

--- a/src/ducc0/sht/totalconvolve.h
+++ b/src/ducc0/sht/totalconvolve.h
@@ -543,7 +543,7 @@ template<typename T> class ConvolverPlan
             }
           }
       auto subplanes=subarray<3>(planes,{{0, nplanes}, {nbtheta, nbtheta+ntheta_s}, {nbphi, nbphi+nphi_s}});
-      synthesis_2d(aarr, subplanes, mbeam, lmax, lmax, "CC", nthreads);
+      synthesis_2d(aarr, subplanes, mbeam, lmax, lmax, "CC", nthreads, STANDARD);
       for (size_t iplane=0; iplane<nplanes; ++iplane)
         {
         auto m = subarray<2>(planes, {{iplane},{nbtheta, nbtheta+ntheta_b}, {nbphi, nbphi+nphi_b}});
@@ -659,7 +659,7 @@ template<typename T> class ConvolverPlan
       auto subplanes=subarray<3>(planes, {{0, nplanes}, {nbtheta, nbtheta+ntheta_s}, {nbphi,nbphi+nphi_s}});
 
       vmav<complex<T>,2> aarr({nplanes, base.Num_Alms()}, UNINITIALIZED);
-      adjoint_synthesis_2d(aarr, subplanes, mbeam, lmax, lmax, "CC", nthreads);
+      adjoint_synthesis_2d(aarr, subplanes, mbeam, lmax, lmax, "CC", nthreads, STANDARD);
       for (size_t m=0; m<=lmax; ++m)
         for (size_t l=m; l<=lmax; ++l)
           if (l>=mbeam)


### PR DESCRIPTION
Implements #11 

This adds a `mode` keyword to most of the SHT functions. Default is `"STANDARD"`, which leads to the original behaviour. `"GRAD_ONLY"` expects two map components and one alm component, and should behave as if the curl a_lm are zero. `"DERIV1"` exists for completeness and behaves analogously to the `_deriv1` functions.

Adjoint functions are implemented as well; they simply don't generate any curl a_lm on output.

Docstrings are not yet updated; I fear they will become quite convoluted, since the array dimensions now depend even more on the values of other parameters.

@carronj , @Sebastian-Belkner , do you want to have a look?