### PR TITLE
Fix CTAD warning.

### DIFF
--- a/src/ducc0/infra/threading.cc
+++ b/src/ducc0/infra/threading.cc
@@ -648,7 +648,7 @@ void Distribution::thread_map(std::function<void(Scheduler &)> f)
   auto new_f = YCombinator([this, &f, &counter, &ex, &ex_mut, pool](auto &new_f, size_t istart, size_t step) -> void {
     try
       {
-      ScopedValueChanger changer(in_parallel_region, true);
+      ScopedValueChanger<bool> changer(in_parallel_region, true);
       ScopedUseThreadPool guard(*pool);
       for(; step>0; step>>=1)
         if(istart+step<nthreads_)
@@ -692,7 +692,7 @@ void Distribution::thread_map(std::function<void(Scheduler &)> f)
     }
   {
   // do remaining work directly on this thread
-  ScopedValueChanger changer(in_parallel_region, true);
+  ScopedValueChanger<bool> changer(in_parallel_region, true);
   MyScheduler sched(*this, 0);
   f(sched);
   }


### PR DESCRIPTION
Without specifying the type explicitly, we get:
```
src/ducc0/infra/threading.cc:651:7: error: 'ScopedValueChanger' may not intend to support class template argument deduction [-Werror,-Wctad-maybe-unsupported]
```
The solutions are either to explicitly specify the tool (simply `bool` in this case), and/or add deduction guides.  The former was easier for now, but we can certainly add deduction guides later if needed.