### PR TITLE
Fully-qualify std::swap for pointer/size_t.

### DIFF
--- a/src/ducc0/infra/aligned_array.h
+++ b/src/ducc0/infra/aligned_array.h
@@ -131,8 +131,8 @@ template<typename T, size_t alignment=alignof(T)> class array_base
     array_base &operator=(const array_base &) = delete;
     array_base &operator=(array_base &&other)
       {
-      swap(p, other.p);
-      swap(sz, other.sz);
+      std::swap(p, other.p);
+      std::swap(sz, other.sz);
       return *this;
       }
 


### PR DESCRIPTION
The ustream clang dev branch found this unqualified swap:
```
ducc/src/ducc0/infra/aligned_array.h:135:7: error: use of undeclared identifier 'swap'
  135 |       swap(sz, other.sz);
```
It seems the function isn't ever actually used, which is why it wasn't previously uncovered.  The latest clang, however, is enforcing more strict checks on template code, leading to build failures.