### PR TITLE
Fix required headers.

### DIFF
--- a/src/ducc0/infra/aligned_array.h
+++ b/src/ducc0/infra/aligned_array.h
@@ -52,6 +52,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef DUCC0_ALIGNED_ARRAY_H
 #define DUCC0_ALIGNED_ARRAY_H
 
+#include <algorithm>
 #include <cstdlib>
 #include <new>
 

--- a/src/ducc0/infra/threading.h
+++ b/src/ducc0/infra/threading.h
@@ -81,11 +81,12 @@ static_assert(false, "DUCC0_STDCXX_LOWLEVEL_THREADING must not be defined extern
 #include <optional>
 #include <vector>
 
+#include "ducc0/infra/error_handling.h"
+
 // threading-specific headers
 #ifdef DUCC0_STDCXX_LOWLEVEL_THREADING
 #include <mutex>
 #include <condition_variable>
-#include "ducc0/infra/error_handling.h"
 #endif
 
 #ifdef DUCC0_NO_LOWLEVEL_THREADING


### PR DESCRIPTION
- The last update introducing `std::swap` needs the `<algorithm>` header.
- The threading module now requires "error_handling.h" even with custom threading.