### PR TITLE
Fix thread_count computation.

### DIFF
--- a/src/ducc0/fft/fftnd_impl.h
+++ b/src/ducc0/fft/fftnd_impl.h
@@ -149,12 +149,14 @@ struct util // hack to avoid duplicate symbols
     }
 
   static size_t thread_count (size_t nthreads, const fmav_info &info,
-    size_t /*axis*/, size_t /*vlen*/)
+    size_t axis, size_t /*vlen*/)
     {
     if (nthreads==1) return 1;
     size_t size = info.size();
     if (size<32768) return 1;
-    return ducc0::adjust_nthreads(nthreads);
+    size_t max_threads = ducc0::adjust_nthreads(nthreads);
+    size_t rem = size / info.shape(axis);
+    return std::max(size_t(1), std::min(rem, max_threads));
     }
   };
 


### PR DESCRIPTION
Down in `multi_iter`, we attempt to compute `calcShare(nshares, myshare, 0, rem)`. If `rem < nshares`, then we have too many shares (i.e. threads), resulting in `lo == hi`, which then triggers the assertion
```
MR_assert(lo==0, "must not happen");
```
Copying the `rem` calculation to `thread_count` and limiting the number of threads to this value allows us to compute a valid number of shares.