### PR TITLE
Template the input MS type passed into `ms2dirty` 

### DIFF
--- a/src/ducc0/wgridder/wgridder.h
+++ b/src/ducc0/wgridder/wgridder.h
@@ -328,13 +328,13 @@ class Baselines
   };
 
 
-template<typename Tcalc, typename Tacc, typename Tms, typename Timg> class Wgridder
+template<typename Tcalc, typename Tacc, typename Tms, typename Timg, typename Tms_in=cmav<complex<Tms>,2>> class Wgridder
   {
   private:
     constexpr static int log2tile=is_same<Tacc,float>::value ? 5 : 4;
     bool gridding;
     TimerHierarchy timers;
-    const cmav<complex<Tms>,2> &ms_in;
+    const Tms_in &ms_in;
     const vmav<complex<Tms>,2> &ms_out;
     const cmav<Timg,2> &dirty_in;
     const vmav<Timg,2> &dirty_out;
@@ -1620,7 +1620,7 @@ timers.pop();
 
   public:
     Wgridder(const cmav<double,2> &uvw, const cmav<double,1> &freq,
-           const cmav<complex<Tms>,2> &ms_in_, const vmav<complex<Tms>,2> &ms_out_,
+           const Tms_in &ms_in_, const vmav<complex<Tms>,2> &ms_out_,
            const cmav<Timg,2> &dirty_in_, const vmav<Timg,2> &dirty_out_,
            const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_,
            double pixsize_x_, double pixsize_y_, double epsilon_,
@@ -1694,8 +1694,8 @@ timers.pop();
       }
   };
 
-template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void ms2dirty(const cmav<double,2> &uvw,
-  const cmav<double,1> &freq, const cmav<complex<Tms>,2> &ms,
+template<typename Tcalc, typename Tacc, typename Tms, typename Tms_in=cmav<complex<Tms>,2>, typename Timg> void ms2dirty(const cmav<double,2> &uvw,
+  const cmav<double,1> &freq, const Tms_in &ms,
   const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_, double pixsize_x, double pixsize_y, double epsilon,
   bool do_wgridding, size_t nthreads, const vmav<Timg,2> &dirty, size_t verbosity,
   bool negate_v=false, bool divide_by_n=true, double sigma_min=1.1,
@@ -1705,7 +1705,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void ms2dir
   auto dirty_in(vmav<Timg,2>::build_empty());
   auto wgt(wgt_.size()!=0 ? wgt_ : wgt_.build_uniform(ms.shape(), 1.));
   auto mask(mask_.size()!=0 ? mask_ : mask_.build_uniform(ms.shape(), 1));
-  Wgridder<Tcalc, Tacc, Tms, Timg> par(uvw, freq, ms, ms_out, dirty_in, dirty, wgt, mask, pixsize_x,
+  Wgridder<Tcalc, Tacc, Tms, Timg, Tms_in> par(uvw, freq, ms, ms_out, dirty_in, dirty, wgt, mask, pixsize_x,
     pixsize_y, epsilon, do_wgridding, nthreads, verbosity, negate_v,
     divide_by_n, sigma_min, sigma_max, center_x, center_y, allow_nshift);
   }
@@ -1731,8 +1731,7 @@ tuple<size_t, size_t, size_t, size_t, double, double>
  get_facet_data(size_t npix_x, size_t npix_y, size_t nfx, size_t nfy, size_t ifx, size_t ify,
   double pixsize_x, double pixsize_y, double center_x, double center_y);
 
-template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void ms2dirty_faceted(size_t nfx, size_t nfy, const cmav<double,2> &uvw,
-  const cmav<double,1> &freq, const cmav<complex<Tms>,2> &ms,
+template<typename Tcalc, typename Tacc, typename Tms, typename Timg, typename Tms_in=cmav<complex<Tms>,2>> void ms2dirty_faceted(size_t nfx, size_t nfy, const cmav<double,2> &uvw, const cmav<double,1> &freq, const Tms_in &ms,
   const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_, double pixsize_x, double pixsize_y, double epsilon,
   bool do_wgridding, size_t nthreads, const vmav<Timg,2> &dirty, size_t verbosity,
   bool negate_v=false, bool divide_by_n=true, double sigma_min=1.1,
@@ -1779,8 +1778,8 @@ tuple<vmav<uint8_t,2>,size_t,size_t, size_t>  get_tuning_parameters(const cmav<d
   double epsilon, bool do_wgridding, size_t nthreads,
   size_t verbosity, double center_x, double center_y);
 
-template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void ms2dirty_tuning(const cmav<double,2> &uvw,
-  const cmav<double,1> &freq, const cmav<complex<Tms>,2> &ms,
+template<typename Tcalc, typename Tacc, typename Tms, typename Timg, typename Tms_in=cmav<complex<Tms>,2>> void ms2dirty_tuning(const cmav<double,2> &uvw,
+  const cmav<double,1> &freq, const Tms_in &ms,
   const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_, double pixsize_x, double pixsize_y, double epsilon,
   bool do_wgridding, size_t nthreads, const vmav<Timg,2> &dirty, size_t verbosity,
   bool negate_v=false, bool divide_by_n=true, double sigma_min=1.1,


### PR DESCRIPTION
Template the input MS type passed into `ms2dirty` instead of hardcoding as `cmav<complex<Tms>,2>>`

Doing this allows us to pass in a different underlying buffer type when using wgridder. e.g. one that does a callback to get visibilities, which are then perhaps calculated inline (or "on the fly") instead of using raw contigous memory.

The specific use case for us at SKAO is that we want to share one memory buffer between multiple gridders (for different facets) and then apply "facet solutions" for each facet to that memory inside the callback. This allows us to do less reads from disk (or across the network) when working with large data. It also allows for each facet to hold more visibilities in memory at once (when multiple facets are running in parallel) which when gridding large amounts of data with lots of wlayers can have a big performance impact.

There could of course be other use cases that people could use this for. e.g. perhaps generating test/simulated data on the fly or similar.