### PR TITLE
Enhance wgridder interface for full flexibility (backward compatible)

### DIFF
--- a/python/wgridder_pymod.cc
+++ b/python/wgridder_pymod.cc
@@ -72,9 +72,9 @@ py::array Py_vis2dirty_tuning(const py::array &uvw,
   size_t npix_x, size_t npix_y, double pixsize_x, double pixsize_y,
   double epsilon, bool do_wgridding, size_t nthreads,
   size_t verbosity, const py::object &mask, bool flip_u, bool flip_v, bool flip_w, bool divide_by_n,
-  py::object &dirty=None, double sigma_min=1.1, double sigma_max=2.6,
-  double center_x=0., double center_y=0.,
-  bool double_precision_accumulation=false)
+  py::object &dirty, double sigma_min, double sigma_max,
+  double center_x, double center_y,
+  bool double_precision_accumulation)
   {
   if (isPyarr<complex<float>>(vis))
     return Py2_vis2dirty_tuning<float>(uvw, freq, vis, wgt, mask, npix_x, npix_y,
@@ -200,9 +200,9 @@ py::array Py_vis2dirty(const py::array &uvw,
   size_t npix_x, size_t npix_y, double pixsize_x, double pixsize_y,
   double epsilon, bool do_wgridding, size_t nthreads,
   size_t verbosity, const py::object &mask, bool flip_u, bool flip_v, bool flip_w, bool divide_by_n,
-  py::object &dirty=None, double sigma_min=1.1, double sigma_max=2.6,
-  double center_x=0., double center_y=0., bool allow_nshift=true,
-  bool gpu=false, bool double_precision_accumulation=false)
+  py::object &dirty, double sigma_min, double sigma_max,
+  double center_x, double center_y, bool allow_nshift,
+  bool gpu, bool double_precision_accumulation)
   {
   if (isPyarr<complex<float>>(vis))
     return Py2_vis2dirty<float>(uvw, freq, vis, wgt, mask, npix_x, npix_y,
@@ -217,124 +217,6 @@ py::array Py_vis2dirty(const py::array &uvw,
   MR_fail("type matching failed: 'vis' has neither type 'c8' nor 'c16'");
   }
 constexpr auto vis2dirty_DS = R"""(
-Converts visibilities to a dirty image.
-
-Parameters
-----------
-uvw: numpy.ndarray((nrows, 3), dtype=numpy.float64)
-    UVW coordinates from the measurement set
-freq: numpy.ndarray((nchan,), dtype=numpy.float64)
-    channel frequencies
-vis: numpy.ndarray((nrows, nchan), dtype=numpy.complex64 or numpy.complex128)
-    the input visibilities.
-    Its data type determines the precision in which the calculation is carried
-    out.
-wgt: numpy.ndarray((nrows, nchan), float with same precision as `vis`), optional
-    If present, its values are multiplied to the input before gridding
-mask: numpy.ndarray((nrows, nchan), dtype=numpy.uint8), optional
-    If present, only visibilities are processed for which mask!=0
-npix_x, npix_y: int
-    dimensions of the dirty image (must both be even and at least 32)
-    If the `dirty` argument is provided, image dimensions will be inferred from
-    the passed array; in this case npix_x and npix_y must be either consistent
-    with these dimensions, or be zero.
-pixsize_x, pixsize_y: float
-    angular pixel size (in projected radians) of the dirty image
-center_x, center_y: float
-    center of the dirty image relative to the phase center
-    (in projected radians)
-epsilon: float
-    accuracy at which the computation should be done. Must be larger than 2e-13.
-    If `vis` has type numpy.complex64, it must be larger than 1e-5.
-do_wgridding: bool
-    if True, the full w-gridding algorithm is carried out, otherwise
-    the w values are assumed to be zero.
-flip_[uvw]: bool
-    if True, all [uvw] coordinates in uvw are multiplied by -1
-divide_by_n: bool
-    if True, the dirty image pixels are divided by n
-sigma_min, sigma_max: float
-    minimum and maximum allowed oversampling factors
-nthreads: int
-    number of threads to use for the calculation
-verbosity: int
-    0: no output
-    1: some diagnostic output and timings
-dirty: numpy.ndarray((npix_x, npix_y), dtype=float of same precision as `vis`),
-    optional
-    If provided, the dirty image will be written to this array and a handle
-    to it will be returned.
-double_precision_accumulation: bool
-    If True, always use double precision for accumulating operations onto the
-    uv grid. This is necessary to reduce numerical errors in special cases.
-
-Returns
--------
-numpy.ndarray((npix_x, npix_y), dtype=float of same precision as `vis`)
-    the dirty image
-
-Notes
------
-The input arrays should be contiguous and in C memory order.
-Other strides will work, but can degrade performance significantly.
-)""";
-template<typename T> py::array Py2_vis2dirty_tidy(const py::array &uvw_,
-  const py::array &freq_, const py::array &vis_, const py::object &wgt_, const py::object &mask_,
-  size_t npix_x, size_t npix_y, double pixsize_x, double pixsize_y,
-  double epsilon, bool do_wgridding, size_t nthreads, size_t verbosity,
-  bool flip_v, bool divide_by_n, py::object &dirty_, double sigma_min,
-  double sigma_max, double center_x, double center_y, bool allow_nshift,
-  bool gpu, bool double_precision_accumulation)
-  {
-  auto uvw = to_cmav<double,2>(uvw_);
-  auto freq = to_cmav<double,1>(freq_);
-  auto vis = to_cmav<complex<T>,2>(vis_);
-  auto wgt = get_optional_const_Pyarr<T>(wgt_, {vis.shape(0),vis.shape(1)});
-  auto wgt2 = to_cmav<T,2>(wgt);
-  auto mask = get_optional_const_Pyarr<uint8_t>(mask_, {uvw.shape(0),freq.shape(0)});
-  auto mask2 = to_cmav<uint8_t,2>(mask);
-  // sizes must be either both zero or both nonzero
-  MR_assert((npix_x==0)==(npix_y==0), "inconsistent dirty image dimensions");
-  auto dirty = (npix_x==0) ? get_Pyarr<T>(dirty_, 2)
-                           : get_optional_Pyarr<T>(dirty_, {npix_x, npix_y});
-  auto dirty2 = to_vmav<T,2>(dirty);
-  {
-  py::gil_scoped_release release;
-  if (gpu)
-    MR_fail("not supported on GPU yet");
-  else
-    double_precision_accumulation ?
-      ms2dirty<T,double>(uvw,freq,vis,wgt2,mask2,pixsize_x,pixsize_y,epsilon,
-        do_wgridding,nthreads,dirty2,verbosity,false,flip_v,true,divide_by_n, sigma_min,
-        sigma_max, center_x, center_y, allow_nshift) :
-      ms2dirty<T,T>(uvw,freq,vis,wgt2,mask2,pixsize_x,pixsize_y,epsilon,
-        do_wgridding,nthreads,dirty2,verbosity,false,flip_v,true,divide_by_n, sigma_min,
-        sigma_max, center_x, center_y, allow_nshift);
-  }
-  return dirty;
-  }
-py::array Py_vis2dirty_tidy(const py::array &uvw,
-  const py::array &freq, const py::array &vis, const py::object &wgt,
-  size_t npix_x, size_t npix_y, double pixsize_x, double pixsize_y,
-  double epsilon, bool do_wgridding, size_t nthreads,
-  size_t verbosity, const py::object &mask, bool flip_v, bool divide_by_n,
-  py::object &dirty=None, double sigma_min=1.1, double sigma_max=2.6,
-  double center_x=0., double center_y=0., bool allow_nshift=true,
-  bool gpu=false, bool double_precision_accumulation=false)
-  {
-  if (isPyarr<complex<float>>(vis))
-    return Py2_vis2dirty_tidy<float>(uvw, freq, vis, wgt, mask, npix_x, npix_y,
-      pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, verbosity,
-      flip_v, divide_by_n, dirty, sigma_min, sigma_max, center_x, center_y,
-      allow_nshift, gpu, double_precision_accumulation);
-  if (isPyarr<complex<double>>(vis))
-    return Py2_vis2dirty_tidy<double>(uvw, freq, vis, wgt, mask, npix_x, npix_y,
-      pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, verbosity,
-      flip_v, divide_by_n, dirty, sigma_min, sigma_max, center_x, center_y,
-      allow_nshift, gpu, double_precision_accumulation);
-  MR_fail("type matching failed: 'vis' has neither type 'c8' nor 'c16'");
-  }
-constexpr auto vis2dirty_tidy_DS = R"""(
 Converts visibilities to a dirty image.
 
 Parameters
@@ -424,8 +306,8 @@ py::array Py_dirty2vis_tuning(const py::array &uvw,
   const py::array &freq, const py::array &dirty, const py::object &wgt,
   double pixsize_x, double pixsize_y, double epsilon, bool do_wgridding,
   size_t nthreads, size_t verbosity, const py::object &mask,
-  bool flip_u, bool flip_v, bool flip_w, bool divide_by_n, py::object &vis=None, double sigma_min=1.1,
-  double sigma_max=2.6, double center_x=0., double center_y=0.)
+  bool flip_u, bool flip_v, bool flip_w, bool divide_by_n, py::object &vis, double sigma_min,
+  double sigma_max, double center_x, double center_y)
   {
   if (isPyarr<float>(dirty))
     return Py2_dirty2vis_tuning<float>(uvw, freq, dirty, wgt, mask,
@@ -528,9 +410,9 @@ py::array Py_dirty2vis(const py::array &uvw,
   const py::array &freq, const py::array &dirty, const py::object &wgt,
   double pixsize_x, double pixsize_y, double epsilon, bool do_wgridding,
   size_t nthreads, size_t verbosity, const py::object &mask,
-  bool flip_u, bool flip_v, bool flip_w, bool divide_by_n, py::object &vis=None, double sigma_min=1.1,
-  double sigma_max=2.6, double center_x=0., double center_y=0., bool allow_nshift=true,
-  bool gpu=false)
+  bool flip_u, bool flip_v, bool flip_w, bool divide_by_n, py::object &vis, double sigma_min,
+  double sigma_max, double center_x, double center_y, bool allow_nshift,
+  bool gpu)
   {
   if (isPyarr<float>(dirty))
     return Py2_dirty2vis<float>(uvw, freq, dirty, wgt, mask,
@@ -597,113 +479,13 @@ Notes
 The input arrays should be contiguous and in C memory order.
 Other strides will work, but can degrade performance significantly.
 )""";
-template<typename T> py::array Py2_dirty2vis_tidy(const py::array &uvw_,
-  const py::array &freq_, const py::array &dirty_, const py::object &wgt_, const py::object &mask_,
-  double pixsize_x, double pixsize_y, double epsilon, bool do_wgridding,
-  size_t nthreads, size_t verbosity, bool flip_v, bool divide_by_n,
-  py::object &vis_, double sigma_min, double sigma_max, double center_x, double center_y, bool allow_nshift,
-  bool gpu)
-  {
-  auto uvw = to_cmav<double,2>(uvw_);
-  auto freq = to_cmav<double,1>(freq_);
-  auto dirty = to_cmav<T,2>(dirty_);
-  auto wgt = get_optional_const_Pyarr<T>(wgt_, {uvw.shape(0),freq.shape(0)});
-  auto wgt2 = to_cmav<T,2>(wgt);
-  auto mask = get_optional_const_Pyarr<uint8_t>(mask_, {uvw.shape(0),freq.shape(0)});
-  auto mask2 = to_cmav<uint8_t,2>(mask);
-  auto vis = get_optional_Pyarr<complex<T>>(vis_, {uvw.shape(0),freq.shape(0)});
-  auto vis2 = to_vmav<complex<T>,2>(vis);
-  {
-  py::gil_scoped_release release;
-  if (gpu)
-    MR_fail("not supported on GPU yet");
-  else
-    dirty2ms<T,T>(uvw,freq,dirty,wgt2,mask2,pixsize_x,pixsize_y,epsilon,
-      do_wgridding,nthreads,vis2,verbosity,false,flip_v,true,divide_by_n, sigma_min,
-      sigma_max, center_x, center_y, allow_nshift);
-  }
-  return vis;
-  }
-py::array Py_dirty2vis_tidy(const py::array &uvw,
-  const py::array &freq, const py::array &dirty, const py::object &wgt,
-  double pixsize_x, double pixsize_y, double epsilon, bool do_wgridding,
-  size_t nthreads, size_t verbosity, const py::object &mask,
-  bool flip_v, bool divide_by_n, py::object &vis=None, double sigma_min=1.1,
-  double sigma_max=2.6, double center_x=0., double center_y=0., bool allow_nshift=true,
-  bool gpu=false)
-  {
-  if (isPyarr<float>(dirty))
-    return Py2_dirty2vis_tidy<float>(uvw, freq, dirty, wgt, mask,
-      pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, verbosity,
-      flip_v, divide_by_n, vis, sigma_min, sigma_max, center_x, center_y, allow_nshift, gpu);
-  if (isPyarr<double>(dirty))
-    return Py2_dirty2vis_tidy<double>(uvw, freq, dirty, wgt, mask,
-      pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, verbosity,
-      flip_v, divide_by_n, vis, sigma_min, sigma_max, center_x, center_y, allow_nshift, gpu);
-  MR_fail("type matching failed: 'dirty' has neither type 'f4' nor 'f8'");
-  }
-constexpr auto dirty2vis_tidy_DS = R"""(
-Converts a dirty image to visibilities.
-
-Parameters
-----------
-uvw: numpy.ndarray((nrows, 3), dtype=numpy.float64)
-    UVW coordinates from the measurement set
-freq: numpy.ndarray((nchan,), dtype=numpy.float64)
-    channel frequencies
-dirty: numpy.ndarray((npix_l, npix_m), dtype=numpy.float32 or numpy.float64)
-    dirty image
-    Its data type determines the precision in which the calculation is carried
-    out.
-    Both dimensions must be even and at least 32.
-wgt: numpy.ndarray((nrows, nchan), same dtype as `dirty`), optional
-    If present, its values are multiplied to the output
-mask: numpy.ndarray((nrows, nchan), dtype=numpy.uint8), optional
-    If present, only visibilities are processed for which mask!=0
-pixsize_l, pixsize_m: float
-    angular pixel size (in projected radians) of the dirty image
-center_l, center_m: float
-    center of the dirty image relative to the phase center
-    (in projected radians)
-epsilon: float
-    accuracy at which the computation should be done. Must be larger than 2e-13.
-    If `dirty` has type numpy.float32, it must be larger than 1e-5.
-do_wgridding: bool
-    if True, the full w-gridding algorithm is carried out, otherwise
-    the w values are assumed to be zero.
-divide_by_n: bool
-    if True, the dirty image pixels are divided by n
-sigma_min, sigma_max: float
-    minimum and maximum allowed oversampling factors
-nthreads: int
-    number of threads to use for the calculation
-verbosity: int
-    0: no output
-    1: some diagnostic output and timings
-phase_convention: string
-    '+'or '-'
-vis: numpy.ndarray((nrows, nchan), dtype=complex of same precision as `dirty`),
-    optional
-    If provided, the computed visibilities will be stored in this array, and
-    a handle to it will be returned.
-
-Returns
--------
-numpy.ndarray((nrows, nchan), dtype=complex of same precision as `dirty`)
-    the computed visibilities.
-
-Notes
------
-The input arrays should be contiguous and in C memory order.
-Other strides will work, but can degrade performance significantly.
-)""";
 
 py::array Py_ms2dirty(const py::array &uvw,
   const py::array &freq, const py::array &ms, const py::object &wgt,
   size_t npix_x, size_t npix_y, double pixsize_x, double pixsize_y, size_t /*nu*/,
   size_t /*nv*/, double epsilon, bool do_wgridding, size_t nthreads,
   size_t verbosity, const py::object &mask,
-  bool double_precision_accumulation=false, bool gpu=false)
+  bool double_precision_accumulation, bool gpu)
   {
   return Py_vis2dirty(uvw, freq, ms, wgt, npix_x, npix_y, pixsize_x, pixsize_y,
     epsilon, do_wgridding, nthreads, verbosity, mask, false, false, false, true, None, 1.1,
@@ -762,7 +544,7 @@ Other strides will work, but can degrade performance significantly.
 py::array Py_dirty2ms(const py::array &uvw,
   const py::array &freq, const py::array &dirty, const py::object &wgt,
   double pixsize_x, double pixsize_y, size_t /*nu*/, size_t /*nv*/, double epsilon,
-  bool do_wgridding, size_t nthreads, size_t verbosity, const py::object &mask, bool gpu=false)
+  bool do_wgridding, size_t nthreads, size_t verbosity, const py::object &mask, bool gpu)
   {
   return Py_dirty2vis(uvw, freq, dirty, wgt, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, verbosity, mask, false, false, false, true, None, 1.1, 2.6, 0, 0, true, gpu);
   }
@@ -871,20 +653,6 @@ void add_wgridder(py::module_ &msup)
   m.def("dirty2ms", &Py_dirty2ms, dirty2ms_DS, "uvw"_a, "freq"_a, "dirty"_a,
     "wgt"_a=None, "pixsize_x"_a, "pixsize_y"_a, "nu"_a=0, "nv"_a=0, "epsilon"_a,
     "do_wstacking"_a=false, "nthreads"_a=1, "verbosity"_a=0, "mask"_a=None, "gpu"_a=false);
-
-  m2.def("vis2dirty_tidy", &Py_vis2dirty_tidy, vis2dirty_tidy_DS, py::kw_only(), "uvw"_a, "freq"_a, "vis"_a,
-    "wgt"_a=None, "npix_x"_a=0, "npix_y"_a=0, "pixsize_x"_a, "pixsize_y"_a,
-    "epsilon"_a, "do_wgridding"_a=false, "nthreads"_a=1, "verbosity"_a=0,
-    "mask"_a=None, "flip_v"_a=false,
-    "divide_by_n"_a=true, "dirty"_a=None,
-    "sigma_min"_a=1.1, "sigma_max"_a=2.6, "center_x"_a=0., "center_y"_a=0.,
-    "allow_nshift"_a=true, "gpu"_a=false, "double_precision_accumulation"_a=false);
-  m2.def("dirty2vis_tidy", &Py_dirty2vis_tidy, dirty2vis_tidy_DS, py::kw_only(), "uvw"_a, "freq"_a, "dirty"_a,
-    "wgt"_a=None, "pixsize_x"_a, "pixsize_y"_a, "epsilon"_a,
-    "do_wgridding"_a=false, "nthreads"_a=1, "verbosity"_a=0, "mask"_a=None,
-    "flip_v"_a=false,
-    "divide_by_n"_a=true, "vis"_a=None, "sigma_min"_a=1.1,
-    "sigma_max"_a=2.6, "center_x"_a=0., "center_y"_a=0., "allow_nshift"_a=true, "gpu"_a=false);
   }
 
 }

--- a/python/wgridder_pymod.cc
+++ b/python/wgridder_pymod.cc
@@ -278,6 +278,124 @@ Notes
 The input arrays should be contiguous and in C memory order.
 Other strides will work, but can degrade performance significantly.
 )""";
+template<typename T> py::array Py2_vis2dirty_tidy(const py::array &uvw_,
+  const py::array &freq_, const py::array &vis_, const py::object &wgt_, const py::object &mask_,
+  size_t npix_x, size_t npix_y, double pixsize_x, double pixsize_y,
+  double epsilon, bool do_wgridding, size_t nthreads, size_t verbosity,
+  bool flip_v, bool divide_by_n, py::object &dirty_, double sigma_min,
+  double sigma_max, double center_x, double center_y, bool allow_nshift,
+  bool gpu, bool double_precision_accumulation)
+  {
+  auto uvw = to_cmav<double,2>(uvw_);
+  auto freq = to_cmav<double,1>(freq_);
+  auto vis = to_cmav<complex<T>,2>(vis_);
+  auto wgt = get_optional_const_Pyarr<T>(wgt_, {vis.shape(0),vis.shape(1)});
+  auto wgt2 = to_cmav<T,2>(wgt);
+  auto mask = get_optional_const_Pyarr<uint8_t>(mask_, {uvw.shape(0),freq.shape(0)});
+  auto mask2 = to_cmav<uint8_t,2>(mask);
+  // sizes must be either both zero or both nonzero
+  MR_assert((npix_x==0)==(npix_y==0), "inconsistent dirty image dimensions");
+  auto dirty = (npix_x==0) ? get_Pyarr<T>(dirty_, 2)
+                           : get_optional_Pyarr<T>(dirty_, {npix_x, npix_y});
+  auto dirty2 = to_vmav<T,2>(dirty);
+  {
+  py::gil_scoped_release release;
+  if (gpu)
+    MR_fail("not supported on GPU yet");
+  else
+    double_precision_accumulation ?
+      ms2dirty<T,double>(uvw,freq,vis,wgt2,mask2,pixsize_x,pixsize_y,epsilon,
+        do_wgridding,nthreads,dirty2,verbosity,flip_v,divide_by_n, sigma_min,
+        sigma_max, center_x, center_y, allow_nshift, true) :
+      ms2dirty<T,T>(uvw,freq,vis,wgt2,mask2,pixsize_x,pixsize_y,epsilon,
+        do_wgridding,nthreads,dirty2,verbosity,flip_v,divide_by_n, sigma_min,
+        sigma_max, center_x, center_y, allow_nshift, true);
+  }
+  return dirty;
+  }
+py::array Py_vis2dirty_tidy(const py::array &uvw,
+  const py::array &freq, const py::array &vis, const py::object &wgt,
+  size_t npix_x, size_t npix_y, double pixsize_x, double pixsize_y,
+  double epsilon, bool do_wgridding, size_t nthreads,
+  size_t verbosity, const py::object &mask, bool flip_v, bool divide_by_n,
+  py::object &dirty=None, double sigma_min=1.1, double sigma_max=2.6,
+  double center_x=0., double center_y=0., bool allow_nshift=true,
+  bool gpu=false, bool double_precision_accumulation=false)
+  {
+  if (isPyarr<complex<float>>(vis))
+    return Py2_vis2dirty_tidy<float>(uvw, freq, vis, wgt, mask, npix_x, npix_y,
+      pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, verbosity,
+      flip_v, divide_by_n, dirty, sigma_min, sigma_max, center_x, center_y,
+      allow_nshift, gpu, double_precision_accumulation);
+  if (isPyarr<complex<double>>(vis))
+    return Py2_vis2dirty_tidy<double>(uvw, freq, vis, wgt, mask, npix_x, npix_y,
+      pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, verbosity,
+      flip_v, divide_by_n, dirty, sigma_min, sigma_max, center_x, center_y,
+      allow_nshift, gpu, double_precision_accumulation);
+  MR_fail("type matching failed: 'vis' has neither type 'c8' nor 'c16'");
+  }
+constexpr auto vis2dirty_tidy_DS = R"""(
+Converts visibilities to a dirty image.
+
+Parameters
+----------
+uvw: numpy.ndarray((nrows, 3), dtype=numpy.float64)
+    UVW coordinates from the measurement set
+freq: numpy.ndarray((nchan,), dtype=numpy.float64)
+    channel frequencies
+vis: numpy.ndarray((nrows, nchan), dtype=numpy.complex64 or numpy.complex128)
+    the input visibilities.
+    Its data type determines the precision in which the calculation is carried
+    out.
+wgt: numpy.ndarray((nrows, nchan), float with same precision as `vis`), optional
+    If present, its values are multiplied to the input before gridding
+mask: numpy.ndarray((nrows, nchan), dtype=numpy.uint8), optional
+    If present, only visibilities are processed for which mask!=0
+npix_x, npix_y: int
+    dimensions of the dirty image (must both be even and at least 32)
+    If the `dirty` argument is provided, image dimensions will be inferred from
+    the passed array; in this case npix_x and npix_y must be either consistent
+    with these dimensions, or be zero.
+pixsize_x, pixsize_y: float
+    angular pixel size (in projected radians) of the dirty image
+center_x, center_y: float
+    center of the dirty image relative to the phase center
+    (in projected radians)
+epsilon: float
+    accuracy at which the computation should be done. Must be larger than 2e-13.
+    If `vis` has type numpy.complex64, it must be larger than 1e-5.
+do_wgridding: bool
+    if True, the full w-gridding algorithm is carried out, otherwise
+    the w values are assumed to be zero.
+flip_v: bool
+    if True, all v coordinates in uvw are multiplied by -1
+divide_by_n: bool
+    if True, the dirty image pixels are divided by n
+sigma_min, sigma_max: float
+    minimum and maximum allowed oversampling factors
+nthreads: int
+    number of threads to use for the calculation
+verbosity: int
+    0: no output
+    1: some diagnostic output and timings
+dirty: numpy.ndarray((npix_x, npix_y), dtype=float of same precision as `vis`),
+    optional
+    If provided, the dirty image will be written to this array and a handle
+    to it will be returned.
+double_precision_accumulation: bool
+    If True, always use double precision for accumulating operations onto the
+    uv grid. This is necessary to reduce numerical errors in special cases.
+
+Returns
+-------
+numpy.ndarray((npix_x, npix_y), dtype=float of same precision as `vis`)
+    the dirty image
+
+Notes
+-----
+The input arrays should be contiguous and in C memory order.
+Other strides will work, but can degrade performance significantly.
+)""";
 
 template<typename T> py::array Py2_dirty2vis_tuning(const py::array &uvw_,
   const py::array &freq_, const py::array &dirty_, const py::object &wgt_, const py::object &mask_,
@@ -425,6 +543,106 @@ py::array Py_dirty2vis(const py::array &uvw,
   MR_fail("type matching failed: 'dirty' has neither type 'f4' nor 'f8'");
   }
 constexpr auto dirty2vis_DS = R"""(
+Converts a dirty image to visibilities.
+
+Parameters
+----------
+uvw: numpy.ndarray((nrows, 3), dtype=numpy.float64)
+    UVW coordinates from the measurement set
+freq: numpy.ndarray((nchan,), dtype=numpy.float64)
+    channel frequencies
+dirty: numpy.ndarray((npix_x, npix_y), dtype=numpy.float32 or numpy.float64)
+    dirty image
+    Its data type determines the precision in which the calculation is carried
+    out.
+    Both dimensions must be even and at least 32.
+wgt: numpy.ndarray((nrows, nchan), same dtype as `dirty`), optional
+    If present, its values are multiplied to the output
+mask: numpy.ndarray((nrows, nchan), dtype=numpy.uint8), optional
+    If present, only visibilities are processed for which mask!=0
+pixsize_x, pixsize_y: float
+    angular pixel size (in projected radians) of the dirty image
+center_x, center_y: float
+    center of the dirty image relative to the phase center
+    (in projected radians)
+epsilon: float
+    accuracy at which the computation should be done. Must be larger than 2e-13.
+    If `dirty` has type numpy.float32, it must be larger than 1e-5.
+do_wgridding: bool
+    if True, the full w-gridding algorithm is carried out, otherwise
+    the w values are assumed to be zero.
+flip_v: bool
+    if True, all v coordinates in uvw are multiplied by -1
+divide_by_n: bool
+    if True, the dirty image pixels are divided by n
+sigma_min, sigma_max: float
+    minimum and maximum allowed oversampling factors
+nthreads: int
+    number of threads to use for the calculation
+verbosity: int
+    0: no output
+    1: some diagnostic output and timings
+vis: numpy.ndarray((nrows, nchan), dtype=complex of same precision as `dirty`),
+    optional
+    If provided, the computed visibilities will be stored in this array, and
+    a handle to it will be returned.
+
+Returns
+-------
+numpy.ndarray((nrows, nchan), dtype=complex of same precision as `dirty`)
+    the computed visibilities.
+
+Notes
+-----
+The input arrays should be contiguous and in C memory order.
+Other strides will work, but can degrade performance significantly.
+)""";
+template<typename T> py::array Py2_dirty2vis_tidy(const py::array &uvw_,
+  const py::array &freq_, const py::array &dirty_, const py::object &wgt_, const py::object &mask_,
+  double pixsize_x, double pixsize_y, double epsilon, bool do_wgridding,
+  size_t nthreads, size_t verbosity, bool flip_v, bool divide_by_n,
+  py::object &vis_, double sigma_min, double sigma_max, double center_x, double center_y, bool allow_nshift,
+  bool gpu)
+  {
+  auto uvw = to_cmav<double,2>(uvw_);
+  auto freq = to_cmav<double,1>(freq_);
+  auto dirty = to_cmav<T,2>(dirty_);
+  auto wgt = get_optional_const_Pyarr<T>(wgt_, {uvw.shape(0),freq.shape(0)});
+  auto wgt2 = to_cmav<T,2>(wgt);
+  auto mask = get_optional_const_Pyarr<uint8_t>(mask_, {uvw.shape(0),freq.shape(0)});
+  auto mask2 = to_cmav<uint8_t,2>(mask);
+  auto vis = get_optional_Pyarr<complex<T>>(vis_, {uvw.shape(0),freq.shape(0)});
+  auto vis2 = to_vmav<complex<T>,2>(vis);
+  {
+  py::gil_scoped_release release;
+  if (gpu)
+    MR_fail("not supported on GPU yet");
+  else
+    dirty2ms<T,T>(uvw,freq,dirty,wgt2,mask2,pixsize_x,pixsize_y,epsilon,
+      do_wgridding,nthreads,vis2,verbosity,flip_v,divide_by_n, sigma_min,
+      sigma_max, center_x, center_y, allow_nshift, true);
+  }
+  return vis;
+  }
+py::array Py_dirty2vis_tidy(const py::array &uvw,
+  const py::array &freq, const py::array &dirty, const py::object &wgt,
+  double pixsize_x, double pixsize_y, double epsilon, bool do_wgridding,
+  size_t nthreads, size_t verbosity, const py::object &mask,
+  bool flip_v, bool divide_by_n, py::object &vis=None, double sigma_min=1.1,
+  double sigma_max=2.6, double center_x=0., double center_y=0., bool allow_nshift=true,
+  bool gpu=false)
+  {
+  if (isPyarr<float>(dirty))
+    return Py2_dirty2vis_tidy<float>(uvw, freq, dirty, wgt, mask,
+      pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, verbosity,
+      flip_v, divide_by_n, vis, sigma_min, sigma_max, center_x, center_y, allow_nshift, gpu);
+  if (isPyarr<double>(dirty))
+    return Py2_dirty2vis_tidy<double>(uvw, freq, dirty, wgt, mask,
+      pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, verbosity,
+      flip_v, divide_by_n, vis, sigma_min, sigma_max, center_x, center_y, allow_nshift, gpu);
+  MR_fail("type matching failed: 'dirty' has neither type 'f4' nor 'f8'");
+  }
+constexpr auto dirty2vis_tidy_DS = R"""(
 Converts a dirty image to visibilities.
 
 Parameters
@@ -652,6 +870,18 @@ void add_wgridder(py::module_ &msup)
   m.def("dirty2ms", &Py_dirty2ms, dirty2ms_DS, "uvw"_a, "freq"_a, "dirty"_a,
     "wgt"_a=None, "pixsize_x"_a, "pixsize_y"_a, "nu"_a=0, "nv"_a=0, "epsilon"_a,
     "do_wstacking"_a=false, "nthreads"_a=1, "verbosity"_a=0, "mask"_a=None, "gpu"_a=false);
+
+  m2.def("vis2dirty_tidy", &Py_vis2dirty_tidy, vis2dirty_tidy_DS, py::kw_only(), "uvw"_a, "freq"_a, "vis"_a,
+    "wgt"_a=None, "npix_x"_a=0, "npix_y"_a=0, "pixsize_x"_a, "pixsize_y"_a,
+    "epsilon"_a, "do_wgridding"_a=false, "nthreads"_a=1, "verbosity"_a=0,
+    "mask"_a=None, "flip_v"_a=false, "divide_by_n"_a=true, "dirty"_a=None,
+    "sigma_min"_a=1.1, "sigma_max"_a=2.6, "center_x"_a=0., "center_y"_a=0.,
+    "allow_nshift"_a=true, "gpu"_a=false, "double_precision_accumulation"_a=false);
+  m2.def("dirty2vis_tidy", &Py_dirty2vis_tidy, dirty2vis_tidy_DS, py::kw_only(), "uvw"_a, "freq"_a, "dirty"_a,
+    "wgt"_a=None, "pixsize_x"_a, "pixsize_y"_a, "epsilon"_a,
+    "do_wgridding"_a=false, "nthreads"_a=1, "verbosity"_a=0, "mask"_a=None,
+    "flip_v"_a=false, "divide_by_n"_a=true, "vis"_a=None, "sigma_min"_a=1.1,
+    "sigma_max"_a=2.6, "center_x"_a=0., "center_y"_a=0., "allow_nshift"_a=true, "gpu"_a=false);
   }
 
 }

--- a/src/ducc0/wgridder/wgridder.h
+++ b/src/ducc0/wgridder/wgridder.h
@@ -1645,7 +1645,7 @@ timers.pop();
         verbosity(verbosity_),
         divide_by_n(divide_by_n_),
         sigma_min(sigma_min_), sigma_max(sigma_max_),
-        lshift(center_x), mshift(negate_v ? -center_y : center_y),
+        lshift(negate_u ? -center_x : center_x), mshift(negate_v ? -center_y : center_y),
         lmshift((lshift!=0) || (mshift!=0)),
         no_nshift(!allow_nshift)
       {

--- a/src/ducc0/wgridder/wgridder.h
+++ b/src/ducc0/wgridder/wgridder.h
@@ -281,7 +281,7 @@ class Baselines
   public:
     Baselines() = default;
     template<typename T> Baselines(const cmav<T,2> &coord_,
-      const cmav<T,1> &freq, bool negate_u=false, bool negate_v=false, bool negate_w=false)
+      const cmav<T,1> &freq, bool flip_u=false, bool flip_v=false, bool flip_w=false)
       {
       constexpr double speedOfLight = 299792458.;
       MR_assert(coord_.shape(1)==3, "dimension mismatch");
@@ -299,9 +299,9 @@ class Baselines
         fcmax = max(fcmax, abs(f_over_c[i]));
         }
       coord.resize(nrows);
-      double ufac = negate_u ? -1 : 1;
-      double vfac = negate_v ? -1 : 1;
-      double wfac = negate_w ? -1 : 1;
+      double ufac = flip_u ? -1 : 1;
+      double vfac = flip_v ? -1 : 1;
+      double wfac = flip_w ? -1 : 1;
       umax=vmax=0;
       for (size_t i=0; i<coord.size(); ++i)
         {
@@ -1627,7 +1627,7 @@ timers.pop();
            const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_,
            double pixsize_x_, double pixsize_y_, double epsilon_,
            bool do_wgridding_, size_t nthreads_, size_t verbosity_,
-           bool negate_u, bool negate_v, bool negate_w, bool divide_by_n_,
+           bool flip_u, bool flip_v, bool flip_w, bool divide_by_n_,
            double sigma_min_, double sigma_max_,
            double center_x, double center_y, bool allow_nshift)
       : gridding(ms_out_.size()==0),
@@ -1645,12 +1645,12 @@ timers.pop();
         verbosity(verbosity_),
         divide_by_n(divide_by_n_),
         sigma_min(sigma_min_), sigma_max(sigma_max_),
-        lshift(negate_u ? -center_x : center_x), mshift(negate_v ? -center_y : center_y),
+        lshift(flip_u ? -center_x : center_x), mshift(flip_v ? -center_y : center_y),
         lmshift((lshift!=0) || (mshift!=0)),
         no_nshift(!allow_nshift)
       {
       timers.push("Baseline construction");
-      bl = Baselines(uvw, freq, negate_u, negate_v, negate_w);
+      bl = Baselines(uvw, freq, flip_u, flip_v, flip_w);
       MR_assert(bl.Nrows()<(uint64_t(1)<<32), "too many rows in the MS");
       MR_assert(bl.Nchannels()<(uint64_t(1)<<16), "too many channels in the MS");
       timers.pop();
@@ -1701,15 +1701,15 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Tms_in=cmav<compl
   const cmav<double,1> &freq, const Tms_in &ms,
   const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_, double pixsize_x, double pixsize_y, double epsilon,
   bool do_wgridding, size_t nthreads, const vmav<Timg,2> &dirty, size_t verbosity,
-  bool negate_u=false, bool negate_v=false, bool negate_w=false, bool divide_by_n=true, double sigma_min=1.1,
-  double sigma_max=2.6, double center_x=0, double center_y=0, bool allow_nshift=true)
+  bool flip_u, bool flip_v, bool flip_w, bool divide_by_n, double sigma_min,
+  double sigma_max, double center_x, double center_y, bool allow_nshift)
   {
   auto ms_out(vmav<complex<Tms>,2>::build_empty());
   auto dirty_in(vmav<Timg,2>::build_empty());
   auto wgt(wgt_.size()!=0 ? wgt_ : wgt_.build_uniform(ms.shape(), 1.));
   auto mask(mask_.size()!=0 ? mask_ : mask_.build_uniform(ms.shape(), 1));
   Wgridder<Tcalc, Tacc, Tms, Timg, Tms_in> par(uvw, freq, ms, ms_out, dirty_in, dirty, wgt, mask, pixsize_x,
-    pixsize_y, epsilon, do_wgridding, nthreads, verbosity, negate_u, negate_v, negate_w,
+    pixsize_y, epsilon, do_wgridding, nthreads, verbosity, flip_u, flip_v, flip_w,
     divide_by_n, sigma_min, sigma_max, center_x, center_y, allow_nshift);
   }
 
@@ -1717,8 +1717,8 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2
   const cmav<double,1> &freq, const cmav<Timg,2> &dirty,
   const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_, double pixsize_x, double pixsize_y,
   double epsilon, bool do_wgridding, size_t nthreads, const vmav<complex<Tms>,2> &ms,
-  size_t verbosity, bool negate_u=false, bool negate_v=false, bool negate_w=false, bool divide_by_n=true,
-  double sigma_min=1.1, double sigma_max=2.6, double center_x=0, double center_y=0, bool allow_nshift=true)
+  size_t verbosity, bool flip_u, bool flip_v, bool flip_w, bool divide_by_n,
+  double sigma_min, double sigma_max, double center_x, double center_y, bool allow_nshift)
   {
   if (ms.size()==0) return;  // nothing to do
   auto ms_in(ms.build_uniform(ms.shape(),1.));
@@ -1726,7 +1726,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2
   auto wgt(wgt_.size()!=0 ? wgt_ : wgt_.build_uniform(ms.shape(), 1.));
   auto mask(mask_.size()!=0 ? mask_ : mask_.build_uniform(ms.shape(), 1));
   Wgridder<Tcalc, Tacc, Tms, Timg> par(uvw, freq, ms_in, ms, dirty, dirty_out, wgt, mask, pixsize_x,
-    pixsize_y, epsilon, do_wgridding, nthreads, verbosity, negate_u, negate_v, negate_w,
+    pixsize_y, epsilon, do_wgridding, nthreads, verbosity, flip_u, flip_v, flip_w,
     divide_by_n, sigma_min, sigma_max, center_x, center_y, allow_nshift);
   }
 
@@ -1737,8 +1737,8 @@ tuple<size_t, size_t, size_t, size_t, double, double>
 template<typename Tcalc, typename Tacc, typename Tms, typename Timg, typename Tms_in=cmav<complex<Tms>,2>> void ms2dirty_faceted(size_t nfx, size_t nfy, const cmav<double,2> &uvw, const cmav<double,1> &freq, const Tms_in &ms,
   const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_, double pixsize_x, double pixsize_y, double epsilon,
   bool do_wgridding, size_t nthreads, const vmav<Timg,2> &dirty, size_t verbosity,
-  bool negate_u=false, bool negate_v=false, bool negate_w=false, bool divide_by_n=true, double sigma_min=1.1,
-  double sigma_max=2.6, double center_x=0, double center_y=0)
+  bool flip_u, bool flip_v, bool flip_w, bool divide_by_n, double sigma_min,
+  double sigma_max, double center_x, double center_y)
   {
   size_t npix_x=dirty.shape(0), npix_y=dirty.shape(1);
   for (size_t i=0; i<nfx; ++i)
@@ -1746,7 +1746,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg, typename Tm
       {
       auto [startx, starty, stopx, stopy, cx, cy] = get_facet_data(npix_x, npix_y, nfx, nfy, i, j, pixsize_x, pixsize_y, center_x, center_y);
       auto subdirty=subarray<2>(dirty, {{startx, stopx}, {starty, stopy}});
-      ms2dirty<Tcalc,Tacc>(uvw, freq, ms, wgt_, mask_, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, subdirty, verbosity, negate_u, negate_v, negate_w, divide_by_n, sigma_min, sigma_max, cx, cy, true);
+      ms2dirty<Tcalc,Tacc>(uvw, freq, ms, wgt_, mask_, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, subdirty, verbosity, flip_u, flip_v, flip_w, divide_by_n, sigma_min, sigma_max, cx, cy, true);
       }
   }
 
@@ -1754,8 +1754,8 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2
   const cmav<double,1> &freq, const cmav<Timg,2> &dirty,
   const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_, double pixsize_x, double pixsize_y,
   double epsilon, bool do_wgridding, size_t nthreads, const vmav<complex<Tms>,2> &ms,
-  size_t verbosity, bool negate_u=false, bool negate_v=false, bool negate_w=false, bool divide_by_n=true,
-  double sigma_min=1.1, double sigma_max=2.6, double center_x=0, double center_y=0)
+  size_t verbosity, bool flip_u, bool flip_v, bool flip_w, bool divide_by_n,
+  double sigma_min, double sigma_max, double center_x, double center_y)
   {
   size_t npix_x=dirty.shape(0), npix_y=dirty.shape(1);
   size_t istep = (npix_x+nfx-1) / nfx;
@@ -1770,7 +1770,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2
       {
       auto [startx, starty, stopx, stopy, cx, cy] = get_facet_data(npix_x, npix_y, nfx, nfy, i, j, pixsize_x, pixsize_y, center_x, center_y);
       auto subdirty=subarray<2>(dirty, {{startx, stopx}, {starty, stopy}});
-      dirty2ms<Tcalc,Tacc>(uvw, freq, subdirty, wgt_, mask_, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, ms2, verbosity, negate_u, negate_v, negate_w, divide_by_n, sigma_min, sigma_max, cx, cy, true);
+      dirty2ms<Tcalc,Tacc>(uvw, freq, subdirty, wgt_, mask_, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, ms2, verbosity, flip_u, flip_v, flip_w, divide_by_n, sigma_min, sigma_max, cx, cy, true);
       mav_apply([](complex<Tms> &v1, const complex<Tms> &v2){v1+=v2;},nthreads,ms,ms2);
       }
   }
@@ -1785,8 +1785,8 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg, typename Tm
   const cmav<double,1> &freq, const Tms_in &ms,
   const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_, double pixsize_x, double pixsize_y, double epsilon,
   bool do_wgridding, size_t nthreads, const vmav<Timg,2> &dirty, size_t verbosity,
-  bool negate_u=false, bool negate_v=false, bool negate_w=false, bool divide_by_n=true, double sigma_min=1.1,
-  double sigma_max=2.6, double center_x=0, double center_y=0)
+  bool flip_u, bool flip_v, bool flip_w, bool divide_by_n, double sigma_min,
+  double sigma_max, double center_x, double center_y)
   {
   {
   size_t npix_x=dirty.shape(0), npix_y=dirty.shape(1);
@@ -1795,7 +1795,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg, typename Tm
     {
     vmav<Timg,2> tdirty({npix_x+xodd, npix_y+yodd}, UNINITIALIZED);
     ms2dirty_tuning<Tcalc,Tacc>(uvw, freq, ms, wgt_, mask_, pixsize_x, pixsize_y, epsilon,
-               do_wgridding, nthreads, tdirty, verbosity, negate_u, negate_v, negate_w, divide_by_n,
+               do_wgridding, nthreads, tdirty, verbosity, flip_u, flip_v, flip_w, divide_by_n,
                sigma_min, sigma_max, center_x+0.5*pixsize_x*xodd, center_y+0.5*pixsize_y*yodd);
     for (size_t i=0; i<npix_x; ++i)
       for (size_t j=0; j<npix_y; ++j)
@@ -1810,11 +1810,11 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg, typename Tm
     {
     if (nfx==0)  // traditional algorithm
       ms2dirty<Tcalc,Tacc>(uvw, freq, ms, wgt_, mask_, pixsize_x, pixsize_y, epsilon,
-               do_wgridding, nthreads, dirty, verbosity, negate_u, negate_v, negate_w, divide_by_n,
+               do_wgridding, nthreads, dirty, verbosity, flip_u, flip_v, flip_w, divide_by_n,
                sigma_min, sigma_max, center_x, center_y, true);
     else
       ms2dirty_faceted<Tcalc,Tacc>(nfx, nfy, uvw, freq, ms, wgt_, mask_, pixsize_x, pixsize_y, epsilon,
-               do_wgridding, nthreads, dirty, verbosity, negate_u, negate_v, negate_w, divide_by_n,
+               do_wgridding, nthreads, dirty, verbosity, flip_u, flip_v, flip_w, divide_by_n,
                sigma_min, sigma_max, center_x, center_y);
     }
   else
@@ -1824,12 +1824,12 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg, typename Tm
     auto icut_local = icut; // FIXME: stupid hack to work around an oversight in the standard(?)
     mav_apply([&](uint8_t i1, uint8_t i2, uint8_t &out) { out = (i1!=0) && (i2>=icut_local); }, nthreads, mask, bin, mask2);
     ms2dirty_faceted<Tcalc,Tacc>(nfx, nfy, uvw, freq, ms, wgt_, mask2, pixsize_x, pixsize_y, epsilon,
-             do_wgridding, nthreads, dirty, verbosity, negate_u, negate_v, negate_w, divide_by_n,
+             do_wgridding, nthreads, dirty, verbosity, flip_u, flip_v, flip_w, divide_by_n,
              sigma_min, sigma_max, center_x, center_y);
     vmav<Timg,2> dirty2(dirty.shape(), UNINITIALIZED);
     mav_apply([&](uint8_t i1, uint8_t i2, uint8_t &out) { out = (i1!=0) && (i2<icut_local); }, nthreads, mask, bin, mask2);
     ms2dirty<Tcalc,Tacc>(uvw, freq, ms, wgt_, mask2, pixsize_x, pixsize_y, epsilon,
-               do_wgridding, nthreads, dirty2, verbosity, negate_u, negate_v, negate_w, divide_by_n,
+               do_wgridding, nthreads, dirty2, verbosity, flip_u, flip_v, flip_w, divide_by_n,
                sigma_min, sigma_max, center_x, center_y, true);
     mav_apply([&](Timg &v1, Timg v2) {v1+=v2;}, nthreads, dirty, dirty2);
     }
@@ -1839,8 +1839,8 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2
   const cmav<double,1> &freq, const cmav<Timg,2> &dirty,
   const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_, double pixsize_x, double pixsize_y,
   double epsilon, bool do_wgridding, size_t nthreads, const vmav<complex<Tms>,2> &ms,
-  size_t verbosity, bool negate_u=false, bool negate_v=false, bool negate_w=false, bool divide_by_n=true,
-  double sigma_min=1.1, double sigma_max=2.6, double center_x=0, double center_y=0)
+  size_t verbosity, bool flip_u, bool flip_v, bool flip_w, bool divide_by_n,
+  double sigma_min, double sigma_max, double center_x, double center_y)
   {
   {
   size_t npix_x=dirty.shape(0), npix_y=dirty.shape(1);
@@ -1851,7 +1851,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2
     for (size_t i=0; i<npix_x+xodd; ++i)
       for (size_t j=0; j<npix_y+yodd; ++j)
         tdirty(i,j) = ((i<npix_x)&&(j<npix_y)) ? dirty(i,j) : Timg(0);
-    dirty2ms_tuning<Tcalc,Tacc>(uvw, freq, tdirty, wgt_, mask_, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, ms, verbosity, negate_u, negate_v, negate_w, divide_by_n, sigma_min, sigma_max, center_x, center_y);
+    dirty2ms_tuning<Tcalc,Tacc>(uvw, freq, tdirty, wgt_, mask_, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, ms, verbosity, flip_u, flip_v, flip_w, divide_by_n, sigma_min, sigma_max, center_x, center_y);
     return;
     }
   }
@@ -1861,9 +1861,9 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2
   if (bin.size()==0)
     {
     if (nfx==0)  // traditional algorithm
-      dirty2ms<Tcalc,Tacc>(uvw, freq, dirty, wgt_, mask_, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, ms, verbosity, negate_u, negate_v, negate_w, divide_by_n, sigma_min, sigma_max, center_x, center_y, true);
+      dirty2ms<Tcalc,Tacc>(uvw, freq, dirty, wgt_, mask_, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, ms, verbosity, flip_u, flip_v, flip_w, divide_by_n, sigma_min, sigma_max, center_x, center_y, true);
     else
-      dirty2ms_faceted<Tcalc,Tacc>(nfx, nfy, uvw, freq, dirty, wgt_, mask_, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, ms, verbosity, negate_u, negate_v, negate_w, divide_by_n, sigma_min, sigma_max, center_x, center_y);
+      dirty2ms_faceted<Tcalc,Tacc>(nfx, nfy, uvw, freq, dirty, wgt_, mask_, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, ms, verbosity, flip_u, flip_v, flip_w, divide_by_n, sigma_min, sigma_max, center_x, center_y);
     }
   else
     {
@@ -1871,10 +1871,10 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2
     vmav<uint8_t,2> mask2({uvw.shape(0),freq.shape(0)}, UNINITIALIZED);
     auto icut_local = icut; // FIXME: stupid hack to work around an oversight in the standard(?)
     mav_apply([&](uint8_t i1, uint8_t i2, uint8_t &out) { out = (i1!=0) && (i2>=icut_local); }, nthreads, mask, bin, mask2);
-    dirty2ms_faceted<Tcalc,Tacc>(nfx, nfy, uvw, freq, dirty, wgt_, mask2, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, ms, verbosity, negate_u, negate_v, negate_w, divide_by_n, sigma_min, sigma_max, center_x, center_y);
+    dirty2ms_faceted<Tcalc,Tacc>(nfx, nfy, uvw, freq, dirty, wgt_, mask2, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, ms, verbosity, flip_u, flip_v, flip_w, divide_by_n, sigma_min, sigma_max, center_x, center_y);
     mav_apply([&](uint8_t i1, uint8_t i2, uint8_t &out) { out = (i1!=0) && (i2<icut_local); }, nthreads, mask, bin, mask2);
     vmav<complex<Tms>,2> tms(ms.shape(), UNINITIALIZED);
-    dirty2ms<Tcalc,Tacc>(uvw, freq, dirty, wgt_, mask2, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, tms, verbosity, negate_u, negate_v, negate_w, divide_by_n, sigma_min, sigma_max, center_x, center_y, true);
+    dirty2ms<Tcalc,Tacc>(uvw, freq, dirty, wgt_, mask2, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, tms, verbosity, flip_u, flip_v, flip_w, divide_by_n, sigma_min, sigma_max, center_x, center_y, true);
     mav_apply([&](complex<Tms> &v1, complex<Tms> v2) {v1+=v2;}, nthreads, ms, tms);
     }
   }

--- a/src/ducc0/wgridder/wgridder.h
+++ b/src/ducc0/wgridder/wgridder.h
@@ -14,7 +14,7 @@
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-/* Copyright (C) 2019-2023 Max-Planck-Society
+/* Copyright (C) 2019-2024 Max-Planck-Society
    Author: Martin Reinecke */
 
 #ifndef DUCC0_WGRIDDER_H
@@ -281,7 +281,7 @@ class Baselines
   public:
     Baselines() = default;
     template<typename T> Baselines(const cmav<T,2> &coord_,
-      const cmav<T,1> &freq, bool negate_v=false, bool negate_w=false)
+      const cmav<T,1> &freq, bool negate_u=false, bool negate_v=false, bool negate_w=false)
       {
       constexpr double speedOfLight = 299792458.;
       MR_assert(coord_.shape(1)==3, "dimension mismatch");
@@ -299,12 +299,13 @@ class Baselines
         fcmax = max(fcmax, abs(f_over_c[i]));
         }
       coord.resize(nrows);
+      double ufac = negate_u ? -1 : 1;
       double vfac = negate_v ? -1 : 1;
       double wfac = negate_w ? -1 : 1;
       umax=vmax=0;
       for (size_t i=0; i<coord.size(); ++i)
         {
-        coord[i] = UVW(coord_(i,0), vfac*coord_(i,1), wfac*coord_(i,2));
+        coord[i] = UVW(ufac*coord_(i,0), vfac*coord_(i,1), wfac*coord_(i,2));
         umax = max(umax, abs(coord_(i,0)));
         vmax = max(vmax, abs(coord_(i,1)));
         }
@@ -348,7 +349,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg, typename Tm
     bool do_wgridding;
     size_t nthreads;
     size_t verbosity;
-    bool negate_v, divide_by_n;
+    bool divide_by_n;
     double sigma_min, sigma_max;
 
     Baselines bl;
@@ -1626,9 +1627,9 @@ timers.pop();
            const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_,
            double pixsize_x_, double pixsize_y_, double epsilon_,
            bool do_wgridding_, size_t nthreads_, size_t verbosity_,
-           bool negate_v_, bool divide_by_n_, double sigma_min_,
-           double sigma_max_, double center_x, double center_y, bool allow_nshift,
-           bool negate_w)
+           bool negate_u, bool negate_v, bool negate_w, bool divide_by_n_,
+           double sigma_min_, double sigma_max_,
+           double center_x, double center_y, bool allow_nshift)
       : gridding(ms_out_.size()==0),
         timers(gridding ? "gridding" : "degridding"),
         ms_in(ms_in_), ms_out(ms_out_),
@@ -1642,14 +1643,14 @@ timers.pop();
         do_wgridding(do_wgridding_),
         nthreads(adjust_nthreads(nthreads_)),
         verbosity(verbosity_),
-        negate_v(negate_v_), divide_by_n(divide_by_n_),
+        divide_by_n(divide_by_n_),
         sigma_min(sigma_min_), sigma_max(sigma_max_),
         lshift(center_x), mshift(negate_v ? -center_y : center_y),
         lmshift((lshift!=0) || (mshift!=0)),
         no_nshift(!allow_nshift)
       {
       timers.push("Baseline construction");
-      bl = Baselines(uvw, freq, negate_v, negate_w);
+      bl = Baselines(uvw, freq, negate_u, negate_v, negate_w);
       MR_assert(bl.Nrows()<(uint64_t(1)<<32), "too many rows in the MS");
       MR_assert(bl.Nchannels()<(uint64_t(1)<<16), "too many channels in the MS");
       timers.pop();
@@ -1700,24 +1701,24 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Tms_in=cmav<compl
   const cmav<double,1> &freq, const Tms_in &ms,
   const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_, double pixsize_x, double pixsize_y, double epsilon,
   bool do_wgridding, size_t nthreads, const vmav<Timg,2> &dirty, size_t verbosity,
-  bool negate_v=false, bool divide_by_n=true, double sigma_min=1.1,
-  double sigma_max=2.6, double center_x=0, double center_y=0, bool allow_nshift=true, bool negate_w=false)
+  bool negate_u=false, bool negate_v=false, bool negate_w=false, bool divide_by_n=true, double sigma_min=1.1,
+  double sigma_max=2.6, double center_x=0, double center_y=0, bool allow_nshift=true)
   {
   auto ms_out(vmav<complex<Tms>,2>::build_empty());
   auto dirty_in(vmav<Timg,2>::build_empty());
   auto wgt(wgt_.size()!=0 ? wgt_ : wgt_.build_uniform(ms.shape(), 1.));
   auto mask(mask_.size()!=0 ? mask_ : mask_.build_uniform(ms.shape(), 1));
   Wgridder<Tcalc, Tacc, Tms, Timg, Tms_in> par(uvw, freq, ms, ms_out, dirty_in, dirty, wgt, mask, pixsize_x,
-    pixsize_y, epsilon, do_wgridding, nthreads, verbosity, negate_v,
-    divide_by_n, sigma_min, sigma_max, center_x, center_y, allow_nshift, negate_w);
+    pixsize_y, epsilon, do_wgridding, nthreads, verbosity, negate_u, negate_v, negate_w,
+    divide_by_n, sigma_min, sigma_max, center_x, center_y, allow_nshift);
   }
 
 template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2ms(const cmav<double,2> &uvw,
   const cmav<double,1> &freq, const cmav<Timg,2> &dirty,
   const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_, double pixsize_x, double pixsize_y,
   double epsilon, bool do_wgridding, size_t nthreads, const vmav<complex<Tms>,2> &ms,
-  size_t verbosity, bool negate_v=false, bool divide_by_n=true,
-  double sigma_min=1.1, double sigma_max=2.6, double center_x=0, double center_y=0, bool allow_nshift=true, bool negate_w=false)
+  size_t verbosity, bool negate_u=false, bool negate_v=false, bool negate_w=false, bool divide_by_n=true,
+  double sigma_min=1.1, double sigma_max=2.6, double center_x=0, double center_y=0, bool allow_nshift=true)
   {
   if (ms.size()==0) return;  // nothing to do
   auto ms_in(ms.build_uniform(ms.shape(),1.));
@@ -1725,8 +1726,8 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2
   auto wgt(wgt_.size()!=0 ? wgt_ : wgt_.build_uniform(ms.shape(), 1.));
   auto mask(mask_.size()!=0 ? mask_ : mask_.build_uniform(ms.shape(), 1));
   Wgridder<Tcalc, Tacc, Tms, Timg> par(uvw, freq, ms_in, ms, dirty, dirty_out, wgt, mask, pixsize_x,
-    pixsize_y, epsilon, do_wgridding, nthreads, verbosity, negate_v,
-    divide_by_n, sigma_min, sigma_max, center_x, center_y, allow_nshift, negate_w);
+    pixsize_y, epsilon, do_wgridding, nthreads, verbosity, negate_u, negate_v, negate_w,
+    divide_by_n, sigma_min, sigma_max, center_x, center_y, allow_nshift);
   }
 
 tuple<size_t, size_t, size_t, size_t, double, double>
@@ -1736,7 +1737,7 @@ tuple<size_t, size_t, size_t, size_t, double, double>
 template<typename Tcalc, typename Tacc, typename Tms, typename Timg, typename Tms_in=cmav<complex<Tms>,2>> void ms2dirty_faceted(size_t nfx, size_t nfy, const cmav<double,2> &uvw, const cmav<double,1> &freq, const Tms_in &ms,
   const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_, double pixsize_x, double pixsize_y, double epsilon,
   bool do_wgridding, size_t nthreads, const vmav<Timg,2> &dirty, size_t verbosity,
-  bool negate_v=false, bool divide_by_n=true, double sigma_min=1.1,
+  bool negate_u=false, bool negate_v=false, bool negate_w=false, bool divide_by_n=true, double sigma_min=1.1,
   double sigma_max=2.6, double center_x=0, double center_y=0)
   {
   size_t npix_x=dirty.shape(0), npix_y=dirty.shape(1);
@@ -1745,7 +1746,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg, typename Tm
       {
       auto [startx, starty, stopx, stopy, cx, cy] = get_facet_data(npix_x, npix_y, nfx, nfy, i, j, pixsize_x, pixsize_y, center_x, center_y);
       auto subdirty=subarray<2>(dirty, {{startx, stopx}, {starty, stopy}});
-      ms2dirty<Tcalc,Tacc>(uvw, freq, ms, wgt_, mask_, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, subdirty, verbosity, negate_v, divide_by_n, sigma_min, sigma_max, cx, cy, true);
+      ms2dirty<Tcalc,Tacc>(uvw, freq, ms, wgt_, mask_, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, subdirty, verbosity, negate_u, negate_v, negate_w, divide_by_n, sigma_min, sigma_max, cx, cy, true);
       }
   }
 
@@ -1753,7 +1754,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2
   const cmav<double,1> &freq, const cmav<Timg,2> &dirty,
   const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_, double pixsize_x, double pixsize_y,
   double epsilon, bool do_wgridding, size_t nthreads, const vmav<complex<Tms>,2> &ms,
-  size_t verbosity, bool negate_v=false, bool divide_by_n=true,
+  size_t verbosity, bool negate_u=false, bool negate_v=false, bool negate_w=false, bool divide_by_n=true,
   double sigma_min=1.1, double sigma_max=2.6, double center_x=0, double center_y=0)
   {
   size_t npix_x=dirty.shape(0), npix_y=dirty.shape(1);
@@ -1769,7 +1770,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2
       {
       auto [startx, starty, stopx, stopy, cx, cy] = get_facet_data(npix_x, npix_y, nfx, nfy, i, j, pixsize_x, pixsize_y, center_x, center_y);
       auto subdirty=subarray<2>(dirty, {{startx, stopx}, {starty, stopy}});
-      dirty2ms<Tcalc,Tacc>(uvw, freq, subdirty, wgt_, mask_, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, ms2, verbosity, negate_v, divide_by_n, sigma_min, sigma_max, cx, cy, true);
+      dirty2ms<Tcalc,Tacc>(uvw, freq, subdirty, wgt_, mask_, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, ms2, verbosity, negate_u, negate_v, negate_w, divide_by_n, sigma_min, sigma_max, cx, cy, true);
       mav_apply([](complex<Tms> &v1, const complex<Tms> &v2){v1+=v2;},nthreads,ms,ms2);
       }
   }
@@ -1784,7 +1785,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg, typename Tm
   const cmav<double,1> &freq, const Tms_in &ms,
   const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_, double pixsize_x, double pixsize_y, double epsilon,
   bool do_wgridding, size_t nthreads, const vmav<Timg,2> &dirty, size_t verbosity,
-  bool negate_v=false, bool divide_by_n=true, double sigma_min=1.1,
+  bool negate_u=false, bool negate_v=false, bool negate_w=false, bool divide_by_n=true, double sigma_min=1.1,
   double sigma_max=2.6, double center_x=0, double center_y=0)
   {
   {
@@ -1794,7 +1795,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg, typename Tm
     {
     vmav<Timg,2> tdirty({npix_x+xodd, npix_y+yodd}, UNINITIALIZED);
     ms2dirty_tuning<Tcalc,Tacc>(uvw, freq, ms, wgt_, mask_, pixsize_x, pixsize_y, epsilon,
-               do_wgridding, nthreads, tdirty, verbosity, negate_v, divide_by_n,
+               do_wgridding, nthreads, tdirty, verbosity, negate_u, negate_v, negate_w, divide_by_n,
                sigma_min, sigma_max, center_x+0.5*pixsize_x*xodd, center_y+0.5*pixsize_y*yodd);
     for (size_t i=0; i<npix_x; ++i)
       for (size_t j=0; j<npix_y; ++j)
@@ -1809,11 +1810,11 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg, typename Tm
     {
     if (nfx==0)  // traditional algorithm
       ms2dirty<Tcalc,Tacc>(uvw, freq, ms, wgt_, mask_, pixsize_x, pixsize_y, epsilon,
-               do_wgridding, nthreads, dirty, verbosity, negate_v, divide_by_n,
+               do_wgridding, nthreads, dirty, verbosity, negate_u, negate_v, negate_w, divide_by_n,
                sigma_min, sigma_max, center_x, center_y, true);
     else
       ms2dirty_faceted<Tcalc,Tacc>(nfx, nfy, uvw, freq, ms, wgt_, mask_, pixsize_x, pixsize_y, epsilon,
-               do_wgridding, nthreads, dirty, verbosity, negate_v, divide_by_n,
+               do_wgridding, nthreads, dirty, verbosity, negate_u, negate_v, negate_w, divide_by_n,
                sigma_min, sigma_max, center_x, center_y);
     }
   else
@@ -1823,12 +1824,12 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg, typename Tm
     auto icut_local = icut; // FIXME: stupid hack to work around an oversight in the standard(?)
     mav_apply([&](uint8_t i1, uint8_t i2, uint8_t &out) { out = (i1!=0) && (i2>=icut_local); }, nthreads, mask, bin, mask2);
     ms2dirty_faceted<Tcalc,Tacc>(nfx, nfy, uvw, freq, ms, wgt_, mask2, pixsize_x, pixsize_y, epsilon,
-             do_wgridding, nthreads, dirty, verbosity, negate_v, divide_by_n,
+             do_wgridding, nthreads, dirty, verbosity, negate_u, negate_v, negate_w, divide_by_n,
              sigma_min, sigma_max, center_x, center_y);
     vmav<Timg,2> dirty2(dirty.shape(), UNINITIALIZED);
     mav_apply([&](uint8_t i1, uint8_t i2, uint8_t &out) { out = (i1!=0) && (i2<icut_local); }, nthreads, mask, bin, mask2);
     ms2dirty<Tcalc,Tacc>(uvw, freq, ms, wgt_, mask2, pixsize_x, pixsize_y, epsilon,
-               do_wgridding, nthreads, dirty2, verbosity, negate_v, divide_by_n,
+               do_wgridding, nthreads, dirty2, verbosity, negate_u, negate_v, negate_w, divide_by_n,
                sigma_min, sigma_max, center_x, center_y, true);
     mav_apply([&](Timg &v1, Timg v2) {v1+=v2;}, nthreads, dirty, dirty2);
     }
@@ -1838,7 +1839,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2
   const cmav<double,1> &freq, const cmav<Timg,2> &dirty,
   const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_, double pixsize_x, double pixsize_y,
   double epsilon, bool do_wgridding, size_t nthreads, const vmav<complex<Tms>,2> &ms,
-  size_t verbosity, bool negate_v=false, bool divide_by_n=true,
+  size_t verbosity, bool negate_u=false, bool negate_v=false, bool negate_w=false, bool divide_by_n=true,
   double sigma_min=1.1, double sigma_max=2.6, double center_x=0, double center_y=0)
   {
   {
@@ -1850,7 +1851,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2
     for (size_t i=0; i<npix_x+xodd; ++i)
       for (size_t j=0; j<npix_y+yodd; ++j)
         tdirty(i,j) = ((i<npix_x)&&(j<npix_y)) ? dirty(i,j) : Timg(0);
-    dirty2ms_tuning<Tcalc,Tacc>(uvw, freq, tdirty, wgt_, mask_, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, ms, verbosity, negate_v, divide_by_n, sigma_min, sigma_max, center_x, center_y);
+    dirty2ms_tuning<Tcalc,Tacc>(uvw, freq, tdirty, wgt_, mask_, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, ms, verbosity, negate_u, negate_v, negate_w, divide_by_n, sigma_min, sigma_max, center_x, center_y);
     return;
     }
   }
@@ -1860,9 +1861,9 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2
   if (bin.size()==0)
     {
     if (nfx==0)  // traditional algorithm
-      dirty2ms<Tcalc,Tacc>(uvw, freq, dirty, wgt_, mask_, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, ms, verbosity, negate_v, divide_by_n, sigma_min, sigma_max, center_x, center_y, true);
+      dirty2ms<Tcalc,Tacc>(uvw, freq, dirty, wgt_, mask_, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, ms, verbosity, negate_u, negate_v, negate_w, divide_by_n, sigma_min, sigma_max, center_x, center_y, true);
     else
-      dirty2ms_faceted<Tcalc,Tacc>(nfx, nfy, uvw, freq, dirty, wgt_, mask_, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, ms, verbosity, negate_v, divide_by_n, sigma_min, sigma_max, center_x, center_y);
+      dirty2ms_faceted<Tcalc,Tacc>(nfx, nfy, uvw, freq, dirty, wgt_, mask_, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, ms, verbosity, negate_u, negate_v, negate_w, divide_by_n, sigma_min, sigma_max, center_x, center_y);
     }
   else
     {
@@ -1870,10 +1871,10 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2
     vmav<uint8_t,2> mask2({uvw.shape(0),freq.shape(0)}, UNINITIALIZED);
     auto icut_local = icut; // FIXME: stupid hack to work around an oversight in the standard(?)
     mav_apply([&](uint8_t i1, uint8_t i2, uint8_t &out) { out = (i1!=0) && (i2>=icut_local); }, nthreads, mask, bin, mask2);
-    dirty2ms_faceted<Tcalc,Tacc>(nfx, nfy, uvw, freq, dirty, wgt_, mask2, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, ms, verbosity, negate_v, divide_by_n, sigma_min, sigma_max, center_x, center_y);
+    dirty2ms_faceted<Tcalc,Tacc>(nfx, nfy, uvw, freq, dirty, wgt_, mask2, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, ms, verbosity, negate_u, negate_v, negate_w, divide_by_n, sigma_min, sigma_max, center_x, center_y);
     mav_apply([&](uint8_t i1, uint8_t i2, uint8_t &out) { out = (i1!=0) && (i2<icut_local); }, nthreads, mask, bin, mask2);
     vmav<complex<Tms>,2> tms(ms.shape(), UNINITIALIZED);
-    dirty2ms<Tcalc,Tacc>(uvw, freq, dirty, wgt_, mask2, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, tms, verbosity, negate_v, divide_by_n, sigma_min, sigma_max, center_x, center_y, true);
+    dirty2ms<Tcalc,Tacc>(uvw, freq, dirty, wgt_, mask2, pixsize_x, pixsize_y, epsilon, do_wgridding, nthreads, tms, verbosity, negate_u, negate_v, negate_w, divide_by_n, sigma_min, sigma_max, center_x, center_y, true);
     mav_apply([&](complex<Tms> &v1, complex<Tms> v2) {v1+=v2;}, nthreads, ms, tms);
     }
   }

--- a/src/ducc0/wgridder/wgridder_sycl.h
+++ b/src/ducc0/wgridder/wgridder_sycl.h
@@ -122,7 +122,7 @@ class Baselines
   public:
     Baselines() = default;
     template<typename T> Baselines(const cmav<T,2> &coord_,
-      const cmav<T,1> &freq, bool negate_v=false)
+      const cmav<T,1> &freq, bool negate_u=false, bool negate_v=false, bool negate_w=false)
       {
       constexpr double speedOfLight = 299792458.;
       MR_assert(coord_.shape(1)==3, "dimension mismatch");
@@ -140,11 +140,13 @@ class Baselines
         fcmax = max(fcmax, abs(f_over_c[i]));
         }
       coord.resize(nrows);
+      double ufac = negate_u ? -1 : 1;
       double vfac = negate_v ? -1 : 1;
+      double wfac = negate_w ? -1 : 1;
       umax=vmax=0;
       for (size_t i=0; i<coord.size(); ++i)
         {
-        coord[i] = UVW(coord_(i,0), vfac*coord_(i,1), coord_(i,2));
+        coord[i] = UVW(ufac*coord_(i,0), vfac*coord_(i,1), wfac*coord_(i,2));
         umax = max(umax, abs(coord_(i,0)));
         vmax = max(vmax, abs(coord_(i,1)));
         }
@@ -190,7 +192,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> class Wgrid
     bool do_wgridding;
     size_t nthreads;
     size_t verbosity;
-    bool negate_v, divide_by_n;
+    bool divide_by_n;
     double sigma_min, sigma_max;
 
     Baselines bl;
@@ -1517,7 +1519,7 @@ timers.pop();
            const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_,
            double pixsize_x_, double pixsize_y_, double epsilon_,
            bool do_wgridding_, size_t nthreads_, size_t verbosity_,
-           bool negate_v_, bool divide_by_n_, double sigma_min_,
+           bool negate_u, bool negate_v, bool negate_w, bool divide_by_n_, double sigma_min_,
            double sigma_max_, double center_x, double center_y, bool allow_nshift)
       : gridding(ms_out_.size()==0),
         timers(gridding ? "gridding" : "degridding", "lmask allocation"),
@@ -1539,7 +1541,7 @@ timers.pop();
         no_nshift(!allow_nshift)
       {
       timers.poppush("Baseline construction");
-      bl = Baselines(uvw, freq, negate_v);
+      bl = Baselines(uvw, freq, negate_u, negate_v, negate_w);
       MR_assert(bl.Nrows()<(uint64_t(1)<<32), "too many rows in the MS");
       MR_assert(bl.Nchannels()<(uint64_t(1)<<16), "too many channels in the MS");
       timers.pop();
@@ -1580,7 +1582,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void ms2dir
   const cmav<double,1> &freq, const cmav<complex<Tms>,2> &ms,
   const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_, double pixsize_x, double pixsize_y, double epsilon,
   bool do_wgridding, size_t nthreads, const vmav<Timg,2> &dirty, size_t verbosity,
-  bool negate_v=false, bool divide_by_n=true, double sigma_min=1.1,
+  bool negate_u=false, bool negate_v=false, bool negate_w=false, bool divide_by_n=true, double sigma_min=1.1,
   double sigma_max=2.6, double center_x=0, double center_y=0, bool allow_nshift=true)
   {
   auto ms_out(vmav<complex<Tms>,2>::build_empty());
@@ -1588,7 +1590,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void ms2dir
   auto wgt(wgt_.size()!=0 ? wgt_ : wgt_.build_uniform(ms.shape(), 1.));
   auto mask(mask_.size()!=0 ? mask_ : mask_.build_uniform(ms.shape(), 1));
   Wgridder<Tcalc, Tacc, Tms, Timg> par(uvw, freq, ms, ms_out, dirty_in, dirty, wgt, mask, pixsize_x,
-    pixsize_y, epsilon, do_wgridding, nthreads, verbosity, negate_v,
+    pixsize_y, epsilon, do_wgridding, nthreads, verbosity, negate_u, negate_v, negate_w
     divide_by_n, sigma_min, sigma_max, center_x, center_y, allow_nshift);
   }
 
@@ -1596,7 +1598,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2
   const cmav<double,1> &freq, const cmav<Timg,2> &dirty,
   const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_, double pixsize_x, double pixsize_y,
   double epsilon, bool do_wgridding, size_t nthreads, const vmav<complex<Tms>,2> &ms,
-  size_t verbosity, bool negate_v=false, bool divide_by_n=true,
+  size_t verbosity, bool negate_u=false, bool negate_v=false, bool negate_w=false, bool divide_by_n=true,
   double sigma_min=1.1, double sigma_max=2.6, double center_x=0, double center_y=0, bool allow_nshift=true)
   {
   if (ms.size()==0) return;  // nothing to do
@@ -1605,7 +1607,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2
   auto wgt(wgt_.size()!=0 ? wgt_ : wgt_.build_uniform(ms.shape(), 1.));
   auto mask(mask_.size()!=0 ? mask_ : mask_.build_uniform(ms.shape(), 1));
   Wgridder<Tcalc, Tacc, Tms, Timg> par(uvw, freq, ms_in, ms, dirty, dirty_out, wgt, mask, pixsize_x,
-    pixsize_y, epsilon, do_wgridding, nthreads, verbosity, negate_v,
+    pixsize_y, epsilon, do_wgridding, nthreads, verbosity, negate_u, negate_v, negate_w,
     divide_by_n, sigma_min, sigma_max, center_x, center_y, allow_nshift);
   }
 
@@ -1615,7 +1617,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void ms2dir
   const cmav<double,1> &, const cmav<complex<Tms>,2> &,
   const cmav<Tms,2> &, const cmav<uint8_t,2> &, double, double, double,
   bool, size_t, const vmav<Timg,2> &, size_t,
-  bool=false, bool=true, double=1.1,
+  bool=false, bool=false, bool=false, bool=true, double=1.1,
   double=2.6, double=0, double=0, bool=true)
   { throw runtime_error("no SYCL support available"); }
 
@@ -1623,7 +1625,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2
   const cmav<double,1> &, const cmav<Timg,2> &,
   const cmav<Tms,2> &, const cmav<uint8_t,2> &, double, double,
   double, bool, size_t, const vmav<complex<Tms>,2> &,
-  size_t, bool=false, bool=true,
+  size_t, bool=false, bool=false, bool=false, bool=true,
   double=1.1, double=2.6, double=0, double=0, bool=true)
   { throw runtime_error("no SYCL support available"); }
 

--- a/src/ducc0/wgridder/wgridder_sycl.h
+++ b/src/ducc0/wgridder/wgridder_sycl.h
@@ -1536,7 +1536,7 @@ timers.pop();
         verbosity(verbosity_),
         negate_v(negate_v_), divide_by_n(divide_by_n_),
         sigma_min(sigma_min_), sigma_max(sigma_max_),
-        lshift(center_x), mshift(negate_v ? -center_y : center_y),
+        lshift(negate_u ? -center_x : center_x), mshift(negate_v ? -center_y : center_y),
         lmshift((lshift!=0) || (mshift!=0)),
         no_nshift(!allow_nshift)
       {

--- a/src/ducc0/wgridder/wgridder_sycl.h
+++ b/src/ducc0/wgridder/wgridder_sycl.h
@@ -122,7 +122,7 @@ class Baselines
   public:
     Baselines() = default;
     template<typename T> Baselines(const cmav<T,2> &coord_,
-      const cmav<T,1> &freq, bool negate_u=false, bool negate_v=false, bool negate_w=false)
+      const cmav<T,1> &freq, bool flip_u=false, bool flip_v=false, bool flip_w=false)
       {
       constexpr double speedOfLight = 299792458.;
       MR_assert(coord_.shape(1)==3, "dimension mismatch");
@@ -140,9 +140,9 @@ class Baselines
         fcmax = max(fcmax, abs(f_over_c[i]));
         }
       coord.resize(nrows);
-      double ufac = negate_u ? -1 : 1;
-      double vfac = negate_v ? -1 : 1;
-      double wfac = negate_w ? -1 : 1;
+      double ufac = flip_u ? -1 : 1;
+      double vfac = flip_v ? -1 : 1;
+      double wfac = flip_w ? -1 : 1;
       umax=vmax=0;
       for (size_t i=0; i<coord.size(); ++i)
         {
@@ -1519,7 +1519,7 @@ timers.pop();
            const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_,
            double pixsize_x_, double pixsize_y_, double epsilon_,
            bool do_wgridding_, size_t nthreads_, size_t verbosity_,
-           bool negate_u, bool negate_v, bool negate_w, bool divide_by_n_, double sigma_min_,
+           bool flip_u, bool flip_v, bool flip_w, bool divide_by_n_, double sigma_min_,
            double sigma_max_, double center_x, double center_y, bool allow_nshift)
       : gridding(ms_out_.size()==0),
         timers(gridding ? "gridding" : "degridding", "lmask allocation"),
@@ -1534,14 +1534,14 @@ timers.pop();
         do_wgridding(do_wgridding_),
         nthreads(adjust_nthreads(nthreads_)),
         verbosity(verbosity_),
-        negate_v(negate_v_), divide_by_n(divide_by_n_),
+        flip_v(flip_v_), divide_by_n(divide_by_n_),
         sigma_min(sigma_min_), sigma_max(sigma_max_),
-        lshift(negate_u ? -center_x : center_x), mshift(negate_v ? -center_y : center_y),
+        lshift(flip_u ? -center_x : center_x), mshift(flip_v ? -center_y : center_y),
         lmshift((lshift!=0) || (mshift!=0)),
         no_nshift(!allow_nshift)
       {
       timers.poppush("Baseline construction");
-      bl = Baselines(uvw, freq, negate_u, negate_v, negate_w);
+      bl = Baselines(uvw, freq, flip_u, flip_v, flip_w);
       MR_assert(bl.Nrows()<(uint64_t(1)<<32), "too many rows in the MS");
       MR_assert(bl.Nchannels()<(uint64_t(1)<<16), "too many channels in the MS");
       timers.pop();
@@ -1582,15 +1582,15 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void ms2dir
   const cmav<double,1> &freq, const cmav<complex<Tms>,2> &ms,
   const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_, double pixsize_x, double pixsize_y, double epsilon,
   bool do_wgridding, size_t nthreads, const vmav<Timg,2> &dirty, size_t verbosity,
-  bool negate_u=false, bool negate_v=false, bool negate_w=false, bool divide_by_n=true, double sigma_min=1.1,
-  double sigma_max=2.6, double center_x=0, double center_y=0, bool allow_nshift=true)
+  bool flip_u, bool flip_v, bool flip_w, bool divide_by_n, double sigma_min,
+  double sigma_max, double center_x, double center_y, bool allow_nshift)
   {
   auto ms_out(vmav<complex<Tms>,2>::build_empty());
   auto dirty_in(vmav<Timg,2>::build_empty());
   auto wgt(wgt_.size()!=0 ? wgt_ : wgt_.build_uniform(ms.shape(), 1.));
   auto mask(mask_.size()!=0 ? mask_ : mask_.build_uniform(ms.shape(), 1));
   Wgridder<Tcalc, Tacc, Tms, Timg> par(uvw, freq, ms, ms_out, dirty_in, dirty, wgt, mask, pixsize_x,
-    pixsize_y, epsilon, do_wgridding, nthreads, verbosity, negate_u, negate_v, negate_w
+    pixsize_y, epsilon, do_wgridding, nthreads, verbosity, flip_u, flip_v, flip_w
     divide_by_n, sigma_min, sigma_max, center_x, center_y, allow_nshift);
   }
 
@@ -1598,8 +1598,8 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2
   const cmav<double,1> &freq, const cmav<Timg,2> &dirty,
   const cmav<Tms,2> &wgt_, const cmav<uint8_t,2> &mask_, double pixsize_x, double pixsize_y,
   double epsilon, bool do_wgridding, size_t nthreads, const vmav<complex<Tms>,2> &ms,
-  size_t verbosity, bool negate_u=false, bool negate_v=false, bool negate_w=false, bool divide_by_n=true,
-  double sigma_min=1.1, double sigma_max=2.6, double center_x=0, double center_y=0, bool allow_nshift=true)
+  size_t verbosity, bool flip_u, bool flip_v, bool flip_w, bool divide_by_n,
+  double sigma_min, double sigma_max, double center_x, double center_y, bool allow_nshift)
   {
   if (ms.size()==0) return;  // nothing to do
   auto ms_in(ms.build_uniform(ms.shape(),1.));
@@ -1607,7 +1607,7 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2
   auto wgt(wgt_.size()!=0 ? wgt_ : wgt_.build_uniform(ms.shape(), 1.));
   auto mask(mask_.size()!=0 ? mask_ : mask_.build_uniform(ms.shape(), 1));
   Wgridder<Tcalc, Tacc, Tms, Timg> par(uvw, freq, ms_in, ms, dirty, dirty_out, wgt, mask, pixsize_x,
-    pixsize_y, epsilon, do_wgridding, nthreads, verbosity, negate_u, negate_v, negate_w,
+    pixsize_y, epsilon, do_wgridding, nthreads, verbosity, flip_u, flip_v, flip_w,
     divide_by_n, sigma_min, sigma_max, center_x, center_y, allow_nshift);
   }
 
@@ -1617,16 +1617,16 @@ template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void ms2dir
   const cmav<double,1> &, const cmav<complex<Tms>,2> &,
   const cmav<Tms,2> &, const cmav<uint8_t,2> &, double, double, double,
   bool, size_t, const vmav<Timg,2> &, size_t,
-  bool=false, bool=false, bool=false, bool=true, double=1.1,
-  double=2.6, double=0, double=0, bool=true)
+  bool, bool, bool, bool, double,
+  double, double, double, bool)
   { throw runtime_error("no SYCL support available"); }
 
 template<typename Tcalc, typename Tacc, typename Tms, typename Timg> void dirty2ms_sycl(const cmav<double,2> &,
   const cmav<double,1> &, const cmav<Timg,2> &,
   const cmav<Tms,2> &, const cmav<uint8_t,2> &, double, double,
   double, bool, size_t, const vmav<complex<Tms>,2> &,
-  size_t, bool=false, bool=false, bool=false, bool=true,
-  double=1.1, double=2.6, double=0, double=0, bool=true)
+  size_t, bool, bool, bool, bool,
+  double, double, double, double, bool)
   { throw runtime_error("no SYCL support available"); }
 
 #endif


### PR DESCRIPTION
This prepares the `wgridder` to support the full set of possible conventions (hopefully!).
New frontends following these conventions can be prototyped in pure Python; once  set of candidates has been established, they can be added to `ducc0.wgridder` itself.

Implements #34.
