### PR TITLE
Enable compilation using emscripten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.pyodide*
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,8 @@ if (NOT MSVC)
     if (CMAKE_SYSTEM_PROCESSOR MATCHES "ppc|ppc64|powerpc|powerpc64" OR (APPLE AND CMAKE_OSX_ARCHITECTURES MATCHES "ppc|ppc64"))
         # PowerPC arch does not have -march flag.
         set(DUCC0_ARCH_FLAGS "-mtune=native" CACHE STRING "Compiler flags for specifying target architecture.")
+    elseif (CMAKE_SYSTEM_NAME MATCHES "Emscripten")
+        set(DUCC0_ARCH_FLAGS "" CACHE STRING "Compiler flags for specifying target architecture.")
     else ()
         set(DUCC0_ARCH_FLAGS "-march=native" CACHE STRING "Compiler flags for specifying target architecture.")
     endif ()


### PR DESCRIPTION
Hi,

With the added lines in the PR, I was able to compile ducc0 using emscripten and generate a pyodide python whl for use in the browser.

Compilation would previously fail with the following error:
```bash
clang++: fatal error: unsupported option '-march=' for target 'wasm32-unknown-emscripten'
```