### PR TITLE
Add scikit-build-core CXX compiler detection when no environment variable is set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ version = "0.41.1"
 "Changelog" = "https://gitlab.mpcdf.mpg.de/mtr/ducc/-/blob/ducc0/ChangeLog"
 
 [build-system]
-requires = ["scikit-build-core>0.5", "nanobind>=2.5.0", "pybind11>=2.13.6", "numpy>=1.17.0"]
+requires = ["scikit-build-core>=1.0", "nanobind>=2.5.0", "pybind11>=2.13.6", "numpy>=1.17.0"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
@@ -138,3 +138,6 @@ sdist.include = [
     "python/demos/sht_analysis_demo.py",
     "python/demos/nufft_benchmark.py"
 ]
+
+[tool.scikit-build.env]
+CXX = { env = "CXX" }


### PR DESCRIPTION
A new config field to detect compilers instead of using the `sysconfig` default was added in `scikit-build-core` 1.0: https://github.com/scikit-build/scikit-build-core/pull/1377

https://scikit-build-core.readthedocs.io/en/latest/configuration/index.html#selecting-a-compiler

> By default, scikit-build-core sets `CC`/`CXX` from Python’s `sysconfig` compiler when they are not already set. If a project’s compiler probes break on that compiler (a conda narrow sysroot, a stale venv gcc, a cross or oneAPI toolchain), list the variable in the `env` table to suppress that default and let CMake detect the compiler from `PATH`; an entry that reads from the same name does this without pinning a value:

```
[tool.scikit-build.env]
CC = { env = "CC" }
CXX = { env = "CXX" }
```

- Is `CC` not needed for `ducc`?
- This change needs to be tested.

Related issue: https://github.com/mreineck/ducc/issues/54