### PR TITLE
Add ubuntu-24.04-arm runner for wheels_64bit_linux build

### DIFF
--- a/.github/workflows/wheels_64bit_linux.yml
+++ b/.github/workflows/wheels_64bit_linux.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04]
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
@@ -30,5 +30,5 @@ jobs:
           CIBW_MANYLINUX_PYPY_I686_IMAGE: manylinux_2_28
       - uses: actions/upload-artifact@v4
         with:
-          name: ducc_linux64
+          name: ducc_linux64_${{ runner.arch }}
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
arm64 wheel is not built for PyPI. This allows a `ubuntu-24.04-arm` runner to build it.

Related issue: https://github.com/mreineck/ducc/issues/54